### PR TITLE
Fix login issues

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -52,7 +52,7 @@ def format_info(p):
         'end_date': latest_end_date,
         'placeholder': placeholder,
         'is_recurser': is_recurser,
-        'is_faculty': False,
+        'is_faculty': util.profile_is_faculty(p),
     }
 
     return person_info
@@ -84,17 +84,11 @@ def get_current_faculty():
     the most recent batch!
     '''
     f = rc.get('profiles?role=faculty').data
-    faculty = []
-
-    for p in f:
-        for stint in p['stints']:
-            if stint['type'] in ["employment", 'facilitatorship'] and stint['end_date'] is None:
-                info = cache_person_call(p["id"])
-                info['is_faculty'] = True
-                faculty.append(info)
-                break
-
-    return faculty
+    return [
+        format_info(profile)
+        for profile in f
+        if util.profile_is_faculty(profile)
+    ]
 
 
 def get_current_batches_info():

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -48,11 +48,12 @@ def authorized():
             id=me['id'],
             name=util.name_from_rc_person(me),
             avatar_url=me['image_path'],
-            is_faculty=me['is_faculty'])
+            is_faculty=util.profile_is_faculty(me),
+        )
         db.session.add(user)
         db.session.commit()
-    elif user.faculty != me['is_faculty']:
-        user.faculty = me['is_faculty']
+    elif user.faculty != util.profile_is_faculty(me):
+        user.faculty = util.profile_is_faculty(me)
         db.session.commit()
     session['user_id'] = user.id
     return redirect(url_for('home'))

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -47,7 +47,7 @@ def authorized():
         user = User(
             id=me['id'],
             name=util.name_from_rc_person(me),
-            avatar_url=me['image'],
+            avatar_url=me['image_path'],
             is_faculty=me['is_faculty'])
         db.session.add(user)
         db.session.commit()

--- a/backend/util.py
+++ b/backend/util.py
@@ -66,6 +66,13 @@ def next_window(latest_batches):
     return time_left
 
 
+def profile_is_faculty(profile):
+    for stint in profile['stints']:
+        if stint['type'] in ['employment', 'facilitatorship'] and stint['end_date'] is None:
+            return True
+    return False
+
+
 def admin_access(current_user):
     if app.config.get('DEV') == 'TRUE' or current_user.id == 770 or current_user.id == 1804:
         return True


### PR DESCRIPTION
When we moved to the new RC API in PR #30, a few pieces in the OAuth sign-in flow were left behind, and as a result, users without an existing, valid session could not log in (but users with a session could continue to use the app). This was caused by two things in particular: the avatar URL, and whether or not the user is faculty.

The former is an easy fix, and the latter is only slightly more complicated. See the individual commit messages for more details.

To test, I cleared my cookies for the site, and tried to log in; before this change, I got a stack trace in the server logs:

```
ERROR in app: Exception on /login/authorized [GET]
Traceback (most recent call last):
  File "niceties/venv/lib/python3.6/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "niceties/venv/lib/python3.6/site-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "niceties/venv/lib/python3.6/site-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "niceties/venv/lib/python3.6/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "niceties/venv/lib/python3.6/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "niceties/venv/lib/python3.6/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "niceties/backend/auth.py", line 51, in authorized
    is_faculty=me['is_faculty'])
KeyError: 'is_faculty'
```
