### PR TITLE
switched to using store2 to handle localStorage stringification

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -75,7 +75,7 @@ def cache_people_call(batch_id):
 
 def cache_person_call(person_id):
     p = rc.get('profiles/{}'.format(person_id)).data
-    
+
     return format_info(p)
 
 
@@ -205,8 +205,8 @@ def post_edited_niceties():
 def get_niceties_to_edit():
     is_admin = util.admin_access(current_user())
     nicety_text = util.encode_str(request.form.get("text"))
-    nicety_author = request.form.get("author_id")
-    nicety_target = request.form.get("target_id")
+    nicety_author = json.loads(request.form.get("author_id"))
+    nicety_target = json.loads(request.form.get("target_id"))
     if is_admin is True:
         (Nicety.query
          .filter(Nicety.author_id == nicety_author)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react-dom": "^15.2.1",
     "react-router": "^2.6.1",
     "react-scripts": "0.2.1",
-    "remarkable": "^1.6.2"
+    "remarkable": "^1.6.2",
+    "store2": "^2.12.0"
   },
   "proxy": "http://localhost:8000",
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import NicetyDisplay from './components/NicetyDisplay';
 import Admin from './components/Admin';
 
 
-if (store.get("saved") === null || store.get("saved") === "undefined") {
+if (store.get("saved") === null) {
     store.set("saved", true);
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import './App.css';
 import { Nav, Navbar, NavDropdown, MenuItem } from 'react-bootstrap';
 import React from 'react';
 import $ from 'jquery';
+import store from 'store2';
 
 import octotie from './octotie.png';
 
@@ -11,12 +12,12 @@ import People from './components/People';
 import NicetyDisplay from './components/NicetyDisplay';
 import Admin from './components/Admin';
 
-if (localStorage.getItem("saved") === null || localStorage.getItem("saved") === "undefined") {
-    localStorage.setItem("saved", "true");
+
+if (store.get("saved") === null || store.get("saved") === "undefined") {
+    store.set("saved", true);
 }
 
-
-var App = React.createClass({
+const App = React.createClass({
     loadPeopleFromServer: function(callback) {
         $.ajax({
             url: this.props.people_api,

--- a/src/components/People.js
+++ b/src/components/People.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Modal, Grid } from 'react-bootstrap';
-import $ from 'jquery'
+import $ from 'jquery';
+import store from 'store2';
 
 import PeopleRow from './PeopleRow';
 import SaveButton from "./SaveButton";
@@ -17,30 +18,30 @@ const People = React.createClass({
         this.state.updated_niceties.forEach(function(e) {
             const split_e = e.split(",");
             let anonymous;
-            if (localStorage.getItem("anonymous-" + split_e[0]) === "undefined" || localStorage.getItem("anonymous-" + split_e[0]) === null) {
-                anonymous = "false";
+            if (store.get("anonymous-" + split_e[0]) === "undefined" || store.get("anonymous-" + split_e[0]) === null) {
+                anonymous = false;
             } else {
-                anonymous = localStorage.getItem("anonymous-" + split_e[0]);
+                anonymous = store.get("anonymous-" + split_e[0]);
             }
             let text;
-            if (localStorage.getItem("nicety-" + split_e[0]) === "undefined" || localStorage.getItem("nicety-" + split_e[0]) === null) {
+            if (store.get("nicety-" + split_e[0]) === "undefined" || store.get("nicety-" + split_e[0]) === null) {
                 text = '';
             } else {
-                text = localStorage.getItem("nicety-" + split_e[0]);
+                text = store.get("nicety-" + split_e[0]);
             }
             let noRead;
-            if (localStorage.getItem("no_read-" + split_e[0]) === "undefined" || localStorage.getItem("no_read-" + split_e[0]) === null) {
-                noRead = "false";
+            if (store.get("no_read-" + split_e[0]) === "undefined" || store.get("no_read-" + split_e[0]) === null) {
+                noRead = false;
             } else {
-                noRead = localStorage.getItem("no_read-" + split_e[0]);
+                noRead = store.get("no_read-" + split_e[0]);
             }
             data_to_save.push(
                 {
                     target_id: parseInt(split_e[0], 10),
                     end_date: split_e[1],
-                    anonymous: anonymous.toString(),
+                    anonymous: anonymous,
                     text: text,
-                    no_read: noRead.toString(),
+                    no_read: noRead,
                     date_updated: dateUpdatedStr
                 }
             );
@@ -55,10 +56,10 @@ const People = React.createClass({
             success: function() {
                 this.setState({noSave: true});
                 this.setState({justSaved: true});
-                localStorage.setItem("saved", "true");
+                store.set("saved", true);
                 this.state.updated_niceties.forEach(function(e) {
                     const split_e = e.split(",");
-                    localStorage.setItem("date_updated-" + split_e[0], dateUpdatedStr);
+                    store.set("date_updated-" + split_e[0], dateUpdatedStr);
                 });
                 this.state.updated_niceties.clear();
             }.bind(this),
@@ -69,14 +70,14 @@ const People = React.createClass({
     },
 
     getInitialState: function() {
-        if (localStorage.getItem("saved") === "true") {
+        if (store.get("saved") === true) {
             return {
                 data: [],
                 noSave: true,
                 justSaved: false,
                 updated_niceties: new Set()
             }
-        } else if (localStorage.getItem("saved") === "false") {
+        } else if (store.get("saved") === false) {
             return {
                 data: [],
                 noSave: false,

--- a/src/components/People.js
+++ b/src/components/People.js
@@ -17,24 +17,10 @@ const People = React.createClass({
         const dateUpdatedStr = dateUpdated.toUTCString();
         this.state.updated_niceties.forEach(function(e) {
             const split_e = e.split(",");
-            let anonymous;
-            if (store.get("anonymous-" + split_e[0]) === "undefined" || store.get("anonymous-" + split_e[0]) === null) {
-                anonymous = false;
-            } else {
-                anonymous = store.get("anonymous-" + split_e[0]);
-            }
-            let text;
-            if (store.get("nicety-" + split_e[0]) === "undefined" || store.get("nicety-" + split_e[0]) === null) {
-                text = '';
-            } else {
-                text = store.get("nicety-" + split_e[0]);
-            }
-            let noRead;
-            if (store.get("no_read-" + split_e[0]) === "undefined" || store.get("no_read-" + split_e[0]) === null) {
-                noRead = false;
-            } else {
-                noRead = store.get("no_read-" + split_e[0]);
-            }
+            const anonymous = store.get("anonymous-" + split_e[0], false);
+            const text = store.get("nicety-" + split_e[0], '');
+            const noRead = store.get("no_read-" + split_e[0], false);
+
             data_to_save.push(
                 {
                     target_id: parseInt(split_e[0], 10),

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -27,7 +27,7 @@ const Person = React.createClass({
                 dateUpdated = dataPerson.date_updated;
             }
         }
-        if (foundPerson && store.get("date_updated-" + this.props.data.id) === null || store.get("date_updated-" + this.props.data.id) === "undefined") {
+        if (foundPerson && store.get("date_updated-" + this.props.data.id) === null) {
             if (dataPerson.text !== '' && dataPerson.text !== null) {
                 store.set("nicety-" + this.props.data.id, dataPerson.text);
                 textValue = dataPerson.text;

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import { Checkbox, Image } from 'react-bootstrap';
+import store from 'store2';
 
 import { updated_niceties_spinlock } from "./People";
 
 
 const Person = React.createClass({
-
     getInitialState: function() {
         let textValue = '';
-        let checkValue = "false";
-        let noReadValue = "false";
+        let checkValue = false;
+        let noReadValue = false;
         let dataPerson;
         let foundPerson = false;
         for (var i = 0; i < this.props.fromMe.length; i++) {
@@ -27,39 +27,39 @@ const Person = React.createClass({
                 dateUpdated = dataPerson.date_updated;
             }
         }
-        if (foundPerson && localStorage.getItem("date_updated-" + this.props.data.id) === null || localStorage.getItem("date_updated-" + this.props.data.id) === "undefined") {
+        if (foundPerson && store.get("date_updated-" + this.props.data.id) === null || store.get("date_updated-" + this.props.data.id) === "undefined") {
             if (dataPerson.text !== '' && dataPerson.text !== null) {
-                localStorage.setItem("nicety-" + this.props.data.id, dataPerson.text);
+                store.set("nicety-" + this.props.data.id, dataPerson.text);
                 textValue = dataPerson.text;
             } else {
                 textValue = '';
             }
-            localStorage.setItem("anonymous-" + this.props.data.id, dataPerson.anonymous.toString());
-            checkValue = dataPerson.anonymous.toString();
-            localStorage.setItem("no_read-" + this.props.data.id, dataPerson.no_read.toString());
-            noReadValue = dataPerson.no_read.toString();
-            localStorage.setItem("date_updated-" + this.props.data.id, dateUpdated.toString());
-        } else if (foundPerson && localStorage.getItem("date_updated-" + this.props.data.id) !== dateUpdated) {
+            store.set("anonymous-" + this.props.data.id, dataPerson.anonymous);
+            checkValue = dataPerson.anonymous;
+            store.set("no_read-" + this.props.data.id, dataPerson.no_read);
+            noReadValue = dataPerson.no_read;
+            store.set("date_updated-" + this.props.data.id, dateUpdated);
+        } else if (foundPerson && store.get("date_updated-" + this.props.data.id) !== dateUpdated) {
             if (dataPerson.text !== '' && dataPerson.text !== null) {
-                localStorage.setItem("nicety-" + this.props.data.id, dataPerson.text);
+                store.set("nicety-" + this.props.data.id, dataPerson.text);
                 textValue = dataPerson.text;
             } else {
                 textValue = '';
             }
-            localStorage.setItem("anonymous-" + this.props.data.id, dataPerson.anonymous.toString());
-            checkValue = dataPerson.anonymous.toString();
-            localStorage.setItem("no_read-" + this.props.data.id, dataPerson.no_read.toString());
-            noReadValue = dataPerson.no_read.toString();
-            localStorage.setItem("date_updated-" + this.props.data.id, dateUpdated.toString());
+            store.set("anonymous-" + this.props.data.id, dataPerson.anonymous);
+            checkValue = dataPerson.anonymous;
+            store.set("no_read-" + this.props.data.id, dataPerson.no_read);
+            noReadValue = dataPerson.no_read;
+            store.set("date_updated-" + this.props.data.id, dateUpdated);
         } else {
-            if (localStorage.getItem("nicety-" + this.props.data.id) !== null) {
-                textValue = localStorage.getItem("nicety-" + this.props.data.id);
+            if (store.get("nicety-" + this.props.data.id) !== null) {
+                textValue = store.get("nicety-" + this.props.data.id);
             }
-            if (localStorage.getItem("anonymous-" + this.props.data.id) !== null) {
-                checkValue = localStorage.getItem("anonymous-" + this.props.data.id);
+            if (store.get("anonymous-" + this.props.data.id) !== null) {
+                checkValue = store.get("anonymous-" + this.props.data.id);
             }
-            if (localStorage.getItem("no_read-" + this.props.data.id) !== null) {
-                noReadValue = localStorage.getItem("no_read-" + this.props.data.id);
+            if (store.get("no_read-" + this.props.data.id) !== null) {
+                noReadValue = store.get("no_read-" + this.props.data.id);
             }
         }
         return {
@@ -79,22 +79,22 @@ const Person = React.createClass({
         if (!(addString in this.props.updated_niceties)) {
             this.props.updated_niceties.add(addString);
         }
-        localStorage.setItem("saved", "false");
+        store.set("saved", false);
         this.props.saveReady();
     },
     textareaChange: function(event) {
         this.setState({textValue: event.target.value});
-        localStorage.setItem("nicety-" + this.props.data.id, event.target.value);
+        store.set("nicety-" + this.props.data.id, event.target.value);
         this.updateSave();
     },
     anonymousChange: function(event) {
-        this.setState({checkValue: event.target.checked.toString()});
-        localStorage.setItem("anonymous-" + this.props.data.id, event.target.checked.toString());
+        this.setState({checkValue: event.target.checked});
+        store.set("anonymous-" + this.props.data.id, event.target.checked);
         this.updateSave();
     },
     noReadChange: function(event) {
-        this.setState({noReadValue: event.target.checked.toString()});
-        localStorage.setItem("no_read-" + this.props.data.id, event.target.checked.toString());
+        this.setState({noReadValue: event.target.checked});
+        store.set("no_read-" + this.props.data.id, event.target.checked);
         this.updateSave();
     },
 
@@ -110,40 +110,30 @@ const Person = React.createClass({
 
     render: function() {
         let anonymousRender;
-        if (this.state.checkValue === "true") {
+        if (this.state.checkValue === true) {
             anonymousRender = (
-                <Checkbox
-                    checked
-                    onChange={this.anonymousChange}
-                >
+                <Checkbox checked onChange={this.anonymousChange}>
                     Submit Anonymously
                 </Checkbox>
             );
-        } else if (this.state.checkValue === "false") {
+        } else if (this.state.checkValue === false) {
             anonymousRender = (
-                <Checkbox
-                    onChange={this.anonymousChange}
-                >
+                <Checkbox onChange={this.anonymousChange}>
                     Submit Anonymously
                 </Checkbox>
             );
         }
 
         let noReadRender;
-        if (this.state.noReadValue === "true") {
+        if (this.state.noReadValue === true) {
             noReadRender = (
-                <Checkbox
-                    checked
-                    onChange={this.noReadChange}
-                >
+                <Checkbox checked onChange={this.noReadChange}>
                     Don't Read At Ceremony
                 </Checkbox>
             );
-        } else if (this.state.noReadValue === "false") {
+        } else if (this.state.noReadValue === false) {
             noReadRender = (
-                <Checkbox
-                    onChange={this.noReadChange}
-                >
+                <Checkbox onChange={this.noReadChange}>
                     Don't Read At Ceremony
                 </Checkbox>
             );


### PR DESCRIPTION
Per issue #31, the front-end has been storing entered niceties in browser localStorage, in case the window is closed before saving. This requires the values stored be strings, which is awkward for other types. This patch migrates to using store2 to manage this stringification, removing the potential for string bools or nulls to be passed to the backend.