### PR TITLE
Commit package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5601 @@
+{
+  "name": "niceties",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "autolinker": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.28.1.tgz",
+      "integrity": "sha1-BlK0kYgYefB3XazgzcoyM5QqTkc=",
+      "requires": {
+        "gulp-header": "^1.7.1"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        }
+      }
+    },
+    "bootstrap": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
+    "concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "requires": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "create-react-class": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
+      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
+      "requires": {
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      }
+    },
+    "fsevents": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
+      "integrity": "sha1-VY6Mw4ZD2O9A/kUVhIbQ0ldY7uQ=",
+      "optional": true,
+      "requires": {
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.29"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.9",
+          "bundled": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.0.4",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.0 || ^1.1.13"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "bl": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "readable-stream": "~2.0.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "inherits": "~2.0.0"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "hoek": "2.x.x"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "balanced-match": "^0.4.1",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "bundled": true,
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.x.x"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "1.0.0-rc4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "async": "^1.5.2",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.10"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "fstream": {
+          "version": "1.0.10",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
+          }
+        },
+        "gauge": {
+          "version": "2.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-color": "^0.1.7",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "is-property": "^1.0.0"
+          }
+        },
+        "getpass": {
+          "version": "0.1.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.4",
+          "bundled": true,
+          "optional": true
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-color": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "optional": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.13.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "jsonpointer": "2.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.2",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonpointer": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.3.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.2",
+            "verror": "1.3.6"
+          }
+        },
+        "mime-db": {
+          "version": "1.23.0",
+          "bundled": true,
+          "optional": true
+        },
+        "mime-types": {
+          "version": "2.1.11",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "mime-db": "~1.23.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "optional": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.29",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "mkdirp": "~0.5.0",
+            "nopt": "~3.0.1",
+            "npmlog": "~3.1.2",
+            "rc": "~1.1.0",
+            "request": "2.x",
+            "rimraf": "~2.5.0",
+            "semver": "~5.2.0",
+            "tar": "~2.2.0",
+            "tar-pack": "~3.1.0"
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7",
+          "bundled": true,
+          "optional": true
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "npmlog": {
+          "version": "3.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.6.0",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.3.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "optional": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.1.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~1.0.4"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "buffer-shims": "^1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "request": {
+          "version": "2.73.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "bl": "~1.1.2",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~1.0.0-rc4",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.2.0",
+            "tunnel-agent": "~0.4.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.5.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "semver": {
+          "version": "5.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "hoek": "2.x.x"
+          }
+        },
+        "sshpk": {
+          "version": "1.8.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.13.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "bundled": true,
+          "optional": true
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "bundled": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
+          }
+        },
+        "tar-pack": {
+          "version": "3.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "~2.2.0",
+            "fstream": "~1.0.10",
+            "fstream-ignore": "~1.0.5",
+            "once": "~1.3.3",
+            "readable-stream": "~2.1.4",
+            "rimraf": "~2.5.1",
+            "tar": "~2.2.1",
+            "uid-number": "~0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.2.2",
+          "bundled": true,
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "bundled": true,
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.13.3",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "gulp-header": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
+      "integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
+      "requires": {
+        "concat-with-sourcemaps": "*",
+        "lodash.template": "^4.4.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+    },
+    "history": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz",
+      "integrity": "sha1-SqLeiXoOSGfkU5hDvm7Nsphr/ew=",
+      "requires": {
+        "deep-equal": "^1.0.0",
+        "invariant": "^2.0.0",
+        "query-string": "^3.0.0",
+        "warning": "^2.0.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
+          "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+    },
+    "iconv-lite": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "is-arguments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+    },
+    "is-regex": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "keycode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "query-string": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
+      "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=",
+      "requires": {
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "react": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-15.7.0.tgz",
+      "integrity": "sha512-5/MMRYmpmM0sMTHGLossnJCrmXQIiJilD6y3YN3TzAwGFj6zdnMtFv6xmi65PHKRV+pehIHpT7oy67Sr6s9AHA==",
+      "requires": {
+        "create-react-class": "^15.6.0",
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
+      }
+    },
+    "react-bootstrap": {
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.30.10.tgz",
+      "integrity": "sha1-27ppCVlfKvTZGTfbD5bsjC3y0ag=",
+      "requires": {
+        "babel-runtime": "^6.11.6",
+        "classnames": "^2.2.5",
+        "dom-helpers": "^3.2.0",
+        "invariant": "^2.2.1",
+        "keycode": "^2.1.2",
+        "prop-types": "^15.5.6",
+        "react-overlays": "^0.6.12",
+        "react-prop-types": "^0.4.0",
+        "uncontrollable": "^4.0.1",
+        "warning": "^3.0.0"
+      }
+    },
+    "react-dom": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.7.0.tgz",
+      "integrity": "sha512-mpjXqC2t1FuYsILOLCj0kg6pbg460byZkVA/80VtDmKU/pYmoTdHOtaMcTRIDiyXLz4sIur0cQ04nOC6iGndJg==",
+      "requires": {
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
+      }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-overlays": {
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.6.12.tgz",
+      "integrity": "sha1-oHnHUMxCnX20x0dKlbS1QDPiVcM=",
+      "requires": {
+        "classnames": "^2.2.5",
+        "dom-helpers": "^3.2.0",
+        "react-prop-types": "^0.4.0",
+        "warning": "^3.0.0"
+      }
+    },
+    "react-prop-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
+      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
+      "requires": {
+        "warning": "^3.0.0"
+      }
+    },
+    "react-router": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.8.1.tgz",
+      "integrity": "sha1-c+lJH2zrMW0Pd5gpCBhj43juTtc=",
+      "requires": {
+        "history": "^2.1.2",
+        "hoist-non-react-statics": "^1.2.0",
+        "invariant": "^2.2.1",
+        "loose-envify": "^1.2.0",
+        "warning": "^3.0.0"
+      }
+    },
+    "react-scripts": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-0.2.1.tgz",
+      "integrity": "sha1-eXv6drXhlnvjxBSSxlY4UL2g8H4=",
+      "requires": {
+        "autoprefixer": "6.3.7",
+        "babel-core": "6.11.4",
+        "babel-eslint": "6.1.2",
+        "babel-loader": "6.2.4",
+        "babel-plugin-syntax-trailing-function-commas": "6.8.0",
+        "babel-plugin-transform-class-properties": "6.11.5",
+        "babel-plugin-transform-object-rest-spread": "6.8.0",
+        "babel-plugin-transform-react-constant-elements": "6.9.1",
+        "babel-plugin-transform-runtime": "6.12.0",
+        "babel-preset-es2015": "6.9.0",
+        "babel-preset-es2016": "6.11.3",
+        "babel-preset-react": "6.11.1",
+        "babel-runtime": "6.11.6",
+        "case-sensitive-paths-webpack-plugin": "1.1.2",
+        "chalk": "1.1.3",
+        "cross-spawn": "4.0.0",
+        "css-loader": "0.23.1",
+        "eslint": "3.1.1",
+        "eslint-loader": "1.4.1",
+        "eslint-plugin-flowtype": "2.4.0",
+        "eslint-plugin-import": "1.12.0",
+        "eslint-plugin-jsx-a11y": "2.0.1",
+        "eslint-plugin-react": "5.2.2",
+        "extract-text-webpack-plugin": "1.0.1",
+        "file-loader": "0.9.0",
+        "filesize": "3.3.0",
+        "fs-extra": "0.30.0",
+        "fsevents": "1.0.14",
+        "gzip-size": "3.0.0",
+        "html-webpack-plugin": "2.22.0",
+        "json-loader": "0.5.4",
+        "opn": "4.0.2",
+        "postcss-loader": "0.9.1",
+        "promise": "7.1.1",
+        "rimraf": "2.5.4",
+        "style-loader": "0.13.1",
+        "url-loader": "0.5.7",
+        "webpack": "1.13.1",
+        "webpack-dev-server": "1.14.1",
+        "whatwg-fetch": "1.0.0"
+      },
+      "dependencies": {
+        "Base64": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "accepts": {
+          "version": "1.3.3",
+          "bundled": true,
+          "requires": {
+            "mime-types": "~2.1.11",
+            "negotiator": "0.6.1"
+          }
+        },
+        "acorn": {
+          "version": "3.3.0",
+          "bundled": true
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          }
+        },
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "alphanum-sort": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "amdefine": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "anymatch": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.0",
+            "micromatch": "^2.1.5"
+          }
+        },
+        "argparse": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asap": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "assert": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "util": "0.10.3"
+          }
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true
+        },
+        "async-each": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "autoprefixer": {
+          "version": "6.3.7",
+          "bundled": true,
+          "requires": {
+            "browserslist": "~1.3.4",
+            "caniuse-db": "^1.0.30000488",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^5.0.21",
+            "postcss-value-parser": "^3.2.3"
+          }
+        },
+        "babel-code-frame": {
+          "version": "6.11.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "chalk": "^1.1.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^2.0.0"
+          }
+        },
+        "babel-core": {
+          "version": "6.11.4",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "^6.8.0",
+            "babel-generator": "^6.11.4",
+            "babel-helpers": "^6.8.0",
+            "babel-messages": "^6.8.0",
+            "babel-register": "^6.9.0",
+            "babel-runtime": "^6.9.1",
+            "babel-template": "^6.9.0",
+            "babel-traverse": "^6.11.4",
+            "babel-types": "^6.9.1",
+            "babylon": "^6.7.0",
+            "convert-source-map": "^1.1.0",
+            "debug": "^2.1.1",
+            "json5": "^0.4.0",
+            "lodash": "^4.2.0",
+            "minimatch": "^3.0.2",
+            "path-exists": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "private": "^0.1.6",
+            "shebang-regex": "^1.0.0",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.0"
+          }
+        },
+        "babel-eslint": {
+          "version": "6.1.2",
+          "bundled": true,
+          "requires": {
+            "babel-traverse": "^6.0.20",
+            "babel-types": "^6.0.19",
+            "babylon": "^6.0.18",
+            "lodash.assign": "^4.0.0",
+            "lodash.pickby": "^4.0.0"
+          }
+        },
+        "babel-generator": {
+          "version": "6.11.4",
+          "bundled": true,
+          "requires": {
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.10.2",
+            "detect-indent": "^3.0.1",
+            "lodash": "^4.2.0",
+            "source-map": "^0.5.0"
+          }
+        },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-explode-assignable-expression": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-builder-react-jsx": {
+          "version": "6.9.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.9.0",
+            "esutils": "^2.0.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-traverse": "^6.8.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-define-map": {
+          "version": "6.9.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.9.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-helper-explode-assignable-expression": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-traverse": "^6.8.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-get-function-arity": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.8.0",
+            "babel-traverse": "^6.8.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-optimise-call-expression": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-regex": {
+          "version": "6.9.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.9.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-helper-replace-supers": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-optimise-call-expression": "^6.8.0",
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.8.0",
+            "babel-traverse": "^6.8.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.8.0"
+          }
+        },
+        "babel-loader": {
+          "version": "6.2.4",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "^0.2.11",
+            "mkdirp": "^0.5.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-syntax-async-functions": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-syntax-class-properties": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-syntax-flow": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-syntax-jsx": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-syntax-object-rest-spread": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-class-properties": {
+          "version": "6.11.5",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.8.0",
+            "babel-plugin-syntax-class-properties": "^6.8.0",
+            "babel-runtime": "^6.9.1"
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.10.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.9.0",
+            "babel-template": "^6.9.0",
+            "babel-traverse": "^6.9.0",
+            "babel-types": "^6.10.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.9.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-define-map": "^6.9.0",
+            "babel-helper-function-name": "^6.8.0",
+            "babel-helper-optimise-call-expression": "^6.8.0",
+            "babel-helper-replace-supers": "^6.8.0",
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-template": "^6.9.0",
+            "babel-traverse": "^6.9.0",
+            "babel-types": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-define-map": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.9.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.9.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.11.5",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-strict-mode": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.8.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-replace-supers": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.11.4",
+          "bundled": true,
+          "requires": {
+            "babel-helper-call-delegate": "^6.8.0",
+            "babel-helper-get-function-arity": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-template": "^6.9.0",
+            "babel-traverse": "^6.11.4",
+            "babel-types": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.11.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "regexpu-core": "^2.0.0"
+          }
+        },
+        "babel-plugin-transform-exponentiation-operator": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-binary-assignment-operator-visitor": "^6.8.0",
+            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-flow-strip-types": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-flow": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-object-rest-spread": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-react-constant-elements": {
+          "version": "6.9.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.9.1"
+          }
+        },
+        "babel-plugin-transform-react-display-name": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx": {
+          "version": "6.8.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-react-jsx": "^6.8.0",
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx-self": {
+          "version": "6.11.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx-source": {
+          "version": "6.9.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.11.4",
+          "bundled": true,
+          "requires": {
+            "babel-core": "^6.11.4",
+            "babel-plugin-syntax-async-functions": "^6.8.0",
+            "babel-plugin-transform-es2015-block-scoping": "^6.9.0",
+            "babel-plugin-transform-es2015-for-of": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-traverse": "^6.11.4",
+            "babel-types": "^6.9.0",
+            "babylon": "^6.6.5",
+            "private": "~0.1.5"
+          }
+        },
+        "babel-plugin-transform-runtime": {
+          "version": "6.12.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.11.3",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-preset-es2015": {
+          "version": "6.9.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "^6.3.13",
+            "babel-plugin-transform-es2015-arrow-functions": "^6.3.13",
+            "babel-plugin-transform-es2015-block-scoped-functions": "^6.3.13",
+            "babel-plugin-transform-es2015-block-scoping": "^6.9.0",
+            "babel-plugin-transform-es2015-classes": "^6.9.0",
+            "babel-plugin-transform-es2015-computed-properties": "^6.3.13",
+            "babel-plugin-transform-es2015-destructuring": "^6.9.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "^6.6.0",
+            "babel-plugin-transform-es2015-for-of": "^6.6.0",
+            "babel-plugin-transform-es2015-function-name": "^6.9.0",
+            "babel-plugin-transform-es2015-literals": "^6.3.13",
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.6.0",
+            "babel-plugin-transform-es2015-object-super": "^6.3.13",
+            "babel-plugin-transform-es2015-parameters": "^6.9.0",
+            "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
+            "babel-plugin-transform-es2015-spread": "^6.3.13",
+            "babel-plugin-transform-es2015-sticky-regex": "^6.3.13",
+            "babel-plugin-transform-es2015-template-literals": "^6.6.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "^6.6.0",
+            "babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
+            "babel-plugin-transform-regenerator": "^6.9.0"
+          }
+        },
+        "babel-preset-es2016": {
+          "version": "6.11.3",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-exponentiation-operator": "^6.3.13"
+          }
+        },
+        "babel-preset-react": {
+          "version": "6.11.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-flow": "^6.3.13",
+            "babel-plugin-syntax-jsx": "^6.3.13",
+            "babel-plugin-transform-flow-strip-types": "^6.3.13",
+            "babel-plugin-transform-react-display-name": "^6.3.13",
+            "babel-plugin-transform-react-jsx": "^6.3.13",
+            "babel-plugin-transform-react-jsx-self": "^6.11.0",
+            "babel-plugin-transform-react-jsx-source": "^6.3.13"
+          }
+        },
+        "babel-register": {
+          "version": "6.11.6",
+          "bundled": true,
+          "requires": {
+            "babel-core": "^6.9.0",
+            "babel-runtime": "^6.11.6",
+            "core-js": "^2.4.0",
+            "home-or-tmp": "^1.0.0",
+            "lodash": "^4.2.0",
+            "mkdirp": "^0.5.1",
+            "path-exists": "^1.0.0",
+            "source-map-support": "^0.2.10"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.11.6",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.9.5"
+          }
+        },
+        "babel-template": {
+          "version": "6.9.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.9.0",
+            "babel-traverse": "^6.9.0",
+            "babel-types": "^6.9.0",
+            "babylon": "^6.7.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.12.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "^6.8.0",
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.9.0",
+            "babylon": "^6.7.0",
+            "debug": "^2.2.0",
+            "globals": "^8.3.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-types": {
+          "version": "6.11.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.9.1",
+            "babel-traverse": "^6.9.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.2.0",
+            "to-fast-properties": "^1.0.1"
+          }
+        },
+        "babylon": {
+          "version": "6.8.4",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "base64-js": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "batch": {
+          "version": "0.5.3",
+          "bundled": true
+        },
+        "big.js": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "binary-extensions": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "bluebird": {
+          "version": "3.4.1",
+          "bundled": true
+        },
+        "boolbase": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.6",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^0.4.1",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "pako": "~0.2.0"
+          }
+        },
+        "browserslist": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "caniuse-db": "^1.0.30000506"
+          }
+        },
+        "buffer": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "base64-js": "0.0.8",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "bytes": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "^0.2.0"
+          }
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "camel-case": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case": "^1.1.1"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "caniuse-db": {
+          "version": "1.0.30000512",
+          "bundled": true
+        },
+        "case-sensitive-paths-webpack-plugin": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "change-case": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "camel-case": "^3.0.0",
+            "constant-case": "^2.0.0",
+            "dot-case": "^2.1.0",
+            "header-case": "^1.0.0",
+            "is-lower-case": "^1.1.0",
+            "is-upper-case": "^1.1.0",
+            "lower-case": "^1.1.1",
+            "lower-case-first": "^1.0.0",
+            "no-case": "^2.2.0",
+            "param-case": "^2.1.0",
+            "pascal-case": "^2.0.0",
+            "path-case": "^2.1.0",
+            "sentence-case": "^2.1.0",
+            "snake-case": "^2.1.0",
+            "swap-case": "^1.1.0",
+            "title-case": "^2.1.0",
+            "upper-case": "^1.1.1",
+            "upper-case-first": "^1.1.0"
+          }
+        },
+        "chokidar": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
+          }
+        },
+        "circular-json": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "clap": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3"
+          }
+        },
+        "clean-css": {
+          "version": "3.4.19",
+          "bundled": true,
+          "requires": {
+            "commander": "2.8.x",
+            "source-map": "0.4.x"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.8.1",
+              "bundled": true,
+              "requires": {
+                "graceful-readlink": ">= 1.0.0"
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "cli-width": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "clone": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "coa": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "q": "^1.1.2"
+          }
+        },
+        "code-point-at": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "color": {
+          "version": "0.11.3",
+          "bundled": true,
+          "requires": {
+            "clone": "^1.0.2",
+            "color-convert": "^1.3.0",
+            "color-string": "^0.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "color-name": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "color-string": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "color-name": "^1.0.0"
+          }
+        },
+        "colormin": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "color": "^0.11.0",
+            "css-color-names": "0.0.4"
+          }
+        },
+        "colors": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "bundled": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "compressible": {
+          "version": "2.0.8",
+          "bundled": true,
+          "requires": {
+            "mime-db": ">= 1.23.0 < 2"
+          }
+        },
+        "compression": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "accepts": "~1.3.3",
+            "bytes": "2.3.0",
+            "compressible": "~2.0.8",
+            "debug": "~2.2.0",
+            "on-headers": "~1.0.1",
+            "vary": "~1.1.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "~2.0.0",
+            "typedarray": "~0.0.5"
+          }
+        },
+        "connect-history-api-fallback": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "date-now": "^0.1.4"
+          }
+        },
+        "constant-case": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "snake-case": "^2.1.0",
+            "upper-case": "^1.1.1"
+          }
+        },
+        "constants-browserify": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "content-disposition": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "content-type": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "2.4.1",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cross-spawn": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.2.8",
+          "bundled": true,
+          "requires": {
+            "pbkdf2-compat": "2.0.1",
+            "ripemd160": "0.2.0",
+            "sha.js": "2.2.6"
+          }
+        },
+        "css-color-names": {
+          "version": "0.0.4",
+          "bundled": true
+        },
+        "css-loader": {
+          "version": "0.23.1",
+          "bundled": true,
+          "requires": {
+            "css-selector-tokenizer": "^0.5.1",
+            "cssnano": ">=2.6.1 <4",
+            "loader-utils": "~0.2.2",
+            "lodash.camelcase": "^3.0.1",
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.6",
+            "postcss-modules-extract-imports": "^1.0.0",
+            "postcss-modules-local-by-default": "^1.0.1",
+            "postcss-modules-scope": "^1.0.0",
+            "postcss-modules-values": "^1.1.0",
+            "source-list-map": "^0.1.4"
+          }
+        },
+        "css-select": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
+            "domutils": "1.5.1",
+            "nth-check": "~1.0.1"
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.5.4",
+          "bundled": true,
+          "requires": {
+            "cssesc": "^0.1.0",
+            "fastparse": "^1.1.1"
+          }
+        },
+        "css-what": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "cssesc": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "cssnano": {
+          "version": "3.7.3",
+          "bundled": true,
+          "requires": {
+            "autoprefixer": "^6.3.1",
+            "decamelize": "^1.1.2",
+            "defined": "^1.0.0",
+            "indexes-of": "^1.0.1",
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.14",
+            "postcss-calc": "^5.2.0",
+            "postcss-colormin": "^2.1.8",
+            "postcss-convert-values": "^2.3.4",
+            "postcss-discard-comments": "^2.0.4",
+            "postcss-discard-duplicates": "^2.0.1",
+            "postcss-discard-empty": "^2.0.1",
+            "postcss-discard-overridden": "^0.1.1",
+            "postcss-discard-unused": "^2.2.1",
+            "postcss-filter-plugins": "^2.0.0",
+            "postcss-merge-idents": "^2.1.5",
+            "postcss-merge-longhand": "^2.0.1",
+            "postcss-merge-rules": "^2.0.3",
+            "postcss-minify-font-values": "^1.0.2",
+            "postcss-minify-gradients": "^1.0.1",
+            "postcss-minify-params": "^1.0.4",
+            "postcss-minify-selectors": "^2.0.4",
+            "postcss-normalize-charset": "^1.1.0",
+            "postcss-normalize-url": "^3.0.7",
+            "postcss-ordered-values": "^2.1.0",
+            "postcss-reduce-idents": "^2.2.2",
+            "postcss-reduce-initial": "^1.0.0",
+            "postcss-reduce-transforms": "^1.0.3",
+            "postcss-svgo": "^2.1.1",
+            "postcss-unique-selectors": "^2.0.2",
+            "postcss-value-parser": "^3.2.3",
+            "postcss-zindex": "^2.0.1"
+          }
+        },
+        "csso": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "clap": "^1.0.9",
+            "source-map": "^0.5.3"
+          }
+        },
+        "d": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "es5-ext": "~0.10.2"
+          }
+        },
+        "damerau-levenshtein": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "date-now": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "defined": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "del": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "globby": "^5.0.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "depd": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "get-stdin": "^4.0.1",
+            "minimist": "^1.1.0",
+            "repeating": "^1.1.0"
+          }
+        },
+        "doctrine": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "esutils": "^1.1.6",
+            "isarray": "^1.0.0"
+          },
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6",
+              "bundled": true
+            }
+          }
+        },
+        "dom-converter": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "utila": "~0.3"
+          },
+          "dependencies": {
+            "utila": {
+              "version": "0.3.3",
+              "bundled": true
+            }
+          }
+        },
+        "dom-serializer": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "~1.1.1",
+            "entities": "~1.1.1"
+          },
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.1.3",
+              "bundled": true
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "1.1.7",
+          "bundled": true
+        },
+        "domelementtype": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "domhandler": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "dot-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "duplexer": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "emojis-list": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "encodeurl": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.2.0",
+            "tapable": "^0.1.8"
+          },
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "entities": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "errno": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "prr": "~0.0.0"
+          }
+        },
+        "es5-ext": {
+          "version": "0.10.12",
+          "bundled": true,
+          "requires": {
+            "es6-iterator": "2",
+            "es6-symbol": "~3.1"
+          }
+        },
+        "es6-iterator": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "d": "^0.1.1",
+            "es5-ext": "^0.10.7",
+            "es6-symbol": "3"
+          }
+        },
+        "es6-map": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.11",
+            "es6-iterator": "2",
+            "es6-set": "~0.1.3",
+            "es6-symbol": "~3.1.0",
+            "event-emitter": "~0.3.4"
+          }
+        },
+        "es6-set": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.11",
+            "es6-iterator": "2",
+            "es6-symbol": "3",
+            "event-emitter": "~0.3.4"
+          }
+        },
+        "es6-symbol": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.11"
+          }
+        },
+        "es6-weak-map": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "d": "^0.1.1",
+            "es5-ext": "^0.10.8",
+            "es6-iterator": "2",
+            "es6-symbol": "3"
+          }
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "escope": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "es6-map": "^0.1.3",
+            "es6-weak-map": "^2.0.1",
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "concat-stream": "^1.4.6",
+            "debug": "^2.1.1",
+            "doctrine": "^1.2.2",
+            "es6-map": "^0.1.3",
+            "escope": "^3.6.0",
+            "espree": "^3.1.6",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^1.1.1",
+            "glob": "^7.0.3",
+            "globals": "^9.2.0",
+            "ignore": "^3.1.2",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^0.12.0",
+            "is-my-json-valid": "^2.10.0",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.5.1",
+            "json-stable-stringify": "^1.0.0",
+            "levn": "^0.3.0",
+            "lodash": "^4.0.0",
+            "mkdirp": "^0.5.0",
+            "optionator": "^0.8.1",
+            "path-is-inside": "^1.0.1",
+            "pluralize": "^1.2.1",
+            "progress": "^1.1.8",
+            "require-uncached": "^1.0.2",
+            "shelljs": "^0.6.0",
+            "strip-bom": "^3.0.0",
+            "strip-json-comments": "~1.0.1",
+            "table": "^3.7.8",
+            "text-table": "~0.2.0",
+            "user-home": "^2.0.0"
+          },
+          "dependencies": {
+            "globals": {
+              "version": "9.9.0",
+              "bundled": true
+            },
+            "user-home": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "os-homedir": "^1.0.0"
+              }
+            }
+          }
+        },
+        "eslint-import-resolver-node": {
+          "version": "0.2.2",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "resolve": "^1.1.6"
+          }
+        },
+        "eslint-loader": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "^0.2.7",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "eslint-plugin-flowtype": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.9.0"
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "1.12.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "^1.1.1",
+            "contains-path": "^0.1.0",
+            "debug": "^2.2.0",
+            "doctrine": "1.2.x",
+            "es6-map": "^0.1.3",
+            "es6-set": "^0.1.4",
+            "eslint-import-resolver-node": "^0.2.0",
+            "lodash.cond": "^4.3.0",
+            "lodash.endswith": "^4.0.1",
+            "lodash.find": "^4.3.0",
+            "lodash.findindex": "^4.3.0",
+            "object-assign": "^4.0.1",
+            "pkg-dir": "^1.0.0",
+            "pkg-up": "^1.0.0"
+          }
+        },
+        "eslint-plugin-jsx-a11y": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "damerau-levenshtein": "^1.0.0",
+            "jsx-ast-utils": "^1.0.0",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "eslint-plugin-react": {
+          "version": "5.2.2",
+          "bundled": true,
+          "requires": {
+            "doctrine": "^1.2.2",
+            "jsx-ast-utils": "^1.2.1"
+          }
+        },
+        "espree": {
+          "version": "3.1.7",
+          "bundled": true,
+          "requires": {
+            "acorn": "^3.3.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "esprima": {
+          "version": "2.7.2",
+          "bundled": true
+        },
+        "esrecurse": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "estraverse": "~4.1.0",
+            "object-assign": "^4.0.1"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "4.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "etag": {
+          "version": "1.7.0",
+          "bundled": true
+        },
+        "event-emitter": {
+          "version": "0.3.4",
+          "bundled": true,
+          "requires": {
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.7"
+          }
+        },
+        "eventemitter3": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "events": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "eventsource": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "original": ">=0.0.5"
+          }
+        },
+        "exit-hook": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "requires": {
+            "fill-range": "^2.1.0"
+          }
+        },
+        "express": {
+          "version": "4.14.0",
+          "bundled": true,
+          "requires": {
+            "accepts": "~1.3.3",
+            "array-flatten": "1.1.1",
+            "content-disposition": "0.5.1",
+            "content-type": "~1.0.2",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
+            "finalhandler": "0.5.0",
+            "fresh": "0.3.0",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.1",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~1.1.2",
+            "qs": "6.2.0",
+            "range-parser": "~1.2.0",
+            "send": "0.14.1",
+            "serve-static": "~1.11.1",
+            "type-is": "~1.6.13",
+            "utils-merge": "1.0.0",
+            "vary": "~1.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "extract-text-webpack-plugin": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "async": "^1.5.0",
+            "loader-utils": "^0.2.3",
+            "webpack-sources": "^0.1.0"
+          }
+        },
+        "fast-levenshtein": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "fastparse": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "faye-websocket": {
+          "version": "0.10.0",
+          "bundled": true,
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "file-entry-cache": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "file-loader": {
+          "version": "0.9.0",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "~0.2.5"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "filesize": {
+          "version": "3.3.0",
+          "bundled": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "finalhandler": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "debug": "~2.2.0",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "statuses": "~1.3.0",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "flat-cache": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "circular-json": "^0.3.0",
+            "del": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "write": "^0.2.1"
+          }
+        },
+        "flatten": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "for-in": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "for-own": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "for-in": "^0.1.5"
+          }
+        },
+        "forwarded": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "fresh": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "fs-extra": {
+          "version": "0.30.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-property": "^1.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "glob": {
+          "version": "7.0.5",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
+        "globals": {
+          "version": "8.18.0",
+          "bundled": true
+        },
+        "globby": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.5",
+          "bundled": true
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "gzip-size": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "duplexer": "^0.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "has-own": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "he": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "header-case": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case": "^1.1.3"
+          }
+        },
+        "home-or-tmp": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "^1.0.1",
+            "user-home": "^1.1.1"
+          }
+        },
+        "html-comment-regex": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "html-minifier": {
+          "version": "2.1.7",
+          "bundled": true,
+          "requires": {
+            "change-case": "3.0.x",
+            "clean-css": "3.4.x",
+            "commander": "2.9.x",
+            "he": "1.1.x",
+            "ncname": "1.0.x",
+            "relateurl": "0.2.x",
+            "uglify-js": "2.6.x"
+          }
+        },
+        "html-webpack-plugin": {
+          "version": "2.22.0",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^3.4.1",
+            "html-minifier": "^2.1.6",
+            "loader-utils": "^0.2.15",
+            "lodash": "^4.13.1",
+            "pretty-error": "^2.0.0",
+            "toposort": "^1.0.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "1",
+            "domhandler": "2.1",
+            "domutils": "1.1",
+            "readable-stream": "1.0"
+          },
+          "dependencies": {
+            "domutils": {
+              "version": "1.1.6",
+              "bundled": true,
+              "requires": {
+                "domelementtype": "1"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "http-browserify": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "Base64": "~0.2.0",
+            "inherits": "~2.0.1"
+          }
+        },
+        "http-errors": {
+          "version": "1.5.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.1",
+            "setprototypeof": "1.0.1",
+            "statuses": ">= 1.3.0 < 2"
+          }
+        },
+        "http-proxy": {
+          "version": "1.14.0",
+          "bundled": true,
+          "requires": {
+            "eventemitter3": "1.x.x",
+            "requires-port": "1.x.x"
+          }
+        },
+        "https-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "icss-replace-symbols": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "ieee754": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "indexes-of": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "0.12.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "ansi-regex": "^2.0.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "readline2": "^1.0.1",
+            "run-async": "^0.1.0",
+            "rx-lite": "^3.1.2",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "interpret": {
+          "version": "0.6.6",
+          "bundled": true
+        },
+        "invariant": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "ipaddr.js": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "is-absolute-url": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "is-dotfile": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "is-primitive": "^2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-lower-case": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "lower-case": "^1.1.0"
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.13.1",
+          "bundled": true,
+          "requires": {
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "jsonpointer": "2.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "tryit": "^1.0.1"
+          }
+        },
+        "is-svg": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "html-comment-regex": "^1.1.0"
+          }
+        },
+        "is-upper-case": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "upper-case": "^1.1.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "js-base64": {
+          "version": "2.1.9",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.6.1",
+          "bundled": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
+          }
+        },
+        "jsesc": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "json-loader": {
+          "version": "0.5.4",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "~0.0.0"
+          }
+        },
+        "json3": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "jsonfile": {
+          "version": "2.3.1",
+          "bundled": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsonpointer": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "jsx-ast-utils": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "is-buffer": "^1.0.2"
+          }
+        },
+        "klaw": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.15",
+          "bundled": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
+          },
+          "dependencies": {
+            "json5": {
+              "version": "0.5.0",
+              "bundled": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.14.1",
+          "bundled": true
+        },
+        "lodash._createcompounder": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "lodash.deburr": "^3.0.0",
+            "lodash.words": "^3.0.0"
+          }
+        },
+        "lodash._root": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "lodash.assign": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "lodash.camelcase": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "lodash._createcompounder": "^3.0.0"
+          }
+        },
+        "lodash.cond": {
+          "version": "4.5.1",
+          "bundled": true
+        },
+        "lodash.deburr": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "lodash._root": "^3.0.0"
+          }
+        },
+        "lodash.endswith": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "lodash.find": {
+          "version": "4.5.1",
+          "bundled": true
+        },
+        "lodash.findindex": {
+          "version": "4.5.1",
+          "bundled": true
+        },
+        "lodash.pickby": {
+          "version": "4.5.1",
+          "bundled": true
+        },
+        "lodash.words": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "lodash._root": "^3.0.0"
+          }
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^1.0.1"
+          },
+          "dependencies": {
+            "js-tokens": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "lower-case": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "lower-case-first": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "lower-case": "^1.1.2"
+          }
+        },
+        "lru-cache": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "^1.0.1",
+            "yallist": "^2.0.0"
+          }
+        },
+        "macaddress": {
+          "version": "0.2.8",
+          "bundled": true
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "memory-fs": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
+        "mime": {
+          "version": "1.2.11",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.23.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.11",
+          "bundled": true,
+          "requires": {
+            "mime-db": "~1.23.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "ncname": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "xml-char-classes": "^1.0.0"
+          }
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "no-case": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "lower-case": "^1.1.1"
+          }
+        },
+        "node-libs-browser": {
+          "version": "0.5.3",
+          "bundled": true,
+          "requires": {
+            "assert": "^1.1.1",
+            "browserify-zlib": "~0.1.4",
+            "buffer": "^3.0.3",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "0.0.1",
+            "crypto-browserify": "~3.2.6",
+            "domain-browser": "^1.1.1",
+            "events": "^1.0.0",
+            "http-browserify": "^1.3.2",
+            "https-browserify": "0.0.0",
+            "os-browserify": "~0.1.2",
+            "path-browserify": "0.0.0",
+            "process": "^0.11.0",
+            "punycode": "^1.2.4",
+            "querystring-es3": "~0.2.0",
+            "readable-stream": "^1.1.13",
+            "stream-browserify": "^1.0.0",
+            "string_decoder": "~0.10.25",
+            "timers-browserify": "^1.0.1",
+            "tty-browserify": "0.0.0",
+            "url": "~0.10.1",
+            "util": "~0.10.3",
+            "vm-browserify": "0.0.4"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "normalize-path": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "normalize-range": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "normalize-url": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
+          }
+        },
+        "nth-check": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "boolbase": "~1.0.0"
+          }
+        },
+        "num2fraction": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "number-is-nan": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "object.omit": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "for-own": "^0.1.3",
+            "is-extendable": "^0.1.1"
+          }
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "on-headers": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.3.3",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "opn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "bundled": true
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "optionator": {
+          "version": "0.8.1",
+          "bundled": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "^1.1.0",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          }
+        },
+        "original": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "url-parse": "1.0.x"
+          },
+          "dependencies": {
+            "url-parse": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "querystringify": "0.0.x",
+                "requires-port": "1.0.x"
+              }
+            }
+          }
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "os-homedir": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pako": {
+          "version": "0.2.9",
+          "bundled": true
+        },
+        "param-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "pascal-case": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "camel-case": "^3.0.0",
+            "upper-case-first": "^1.1.0"
+          }
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "path-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "pbkdf2-compat": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^1.0.0"
+          }
+        },
+        "pkg-up": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^1.0.0"
+          }
+        },
+        "pluralize": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "postcss": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.1.2"
+          }
+        },
+        "postcss-calc": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.2",
+            "postcss-message-helpers": "^2.0.0",
+            "reduce-css-calc": "^1.2.0"
+          }
+        },
+        "postcss-colormin": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "colormin": "^1.0.5",
+            "postcss": "^5.0.13",
+            "postcss-value-parser": "^3.2.3"
+          }
+        },
+        "postcss-convert-values": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.11",
+            "postcss-value-parser": "^3.1.2"
+          }
+        },
+        "postcss-discard-comments": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.14"
+          }
+        },
+        "postcss-discard-duplicates": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.4"
+          }
+        },
+        "postcss-discard-empty": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.14"
+          }
+        },
+        "postcss-discard-overridden": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.16"
+          }
+        },
+        "postcss-discard-unused": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "flatten": "1.0.2",
+            "postcss": "^5.0.14",
+            "uniqs": "^2.0.0"
+          }
+        },
+        "postcss-filter-plugins": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.4",
+            "uniqid": "^3.0.0"
+          }
+        },
+        "postcss-loader": {
+          "version": "0.9.1",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "^0.2.14",
+            "postcss": "^5.0.19"
+          }
+        },
+        "postcss-merge-idents": {
+          "version": "2.1.6",
+          "bundled": true,
+          "requires": {
+            "has-own": "^1.0.0",
+            "postcss": "^5.0.10",
+            "postcss-value-parser": "^3.1.1"
+          }
+        },
+        "postcss-merge-longhand": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.4"
+          }
+        },
+        "postcss-merge-rules": {
+          "version": "2.0.10",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.4",
+            "vendors": "^1.0.0"
+          }
+        },
+        "postcss-message-helpers": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "postcss-minify-font-values": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.2"
+          }
+        },
+        "postcss-minify-gradients": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.12",
+            "postcss-value-parser": "^3.1.3"
+          }
+        },
+        "postcss-minify-params": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "alphanum-sort": "^1.0.1",
+            "postcss": "^5.0.2",
+            "postcss-value-parser": "^3.0.2",
+            "uniqs": "^2.0.0"
+          }
+        },
+        "postcss-minify-selectors": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "alphanum-sort": "^1.0.2",
+            "postcss": "^5.0.14",
+            "postcss-selector-parser": "^2.0.0"
+          }
+        },
+        "postcss-modules-extract-imports": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.4"
+          }
+        },
+        "postcss-modules-local-by-default": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "css-selector-tokenizer": "^0.6.0",
+            "postcss": "^5.0.4"
+          },
+          "dependencies": {
+            "css-selector-tokenizer": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "cssesc": "^0.1.0",
+                "fastparse": "^1.1.1",
+                "regexpu-core": "^1.0.0"
+              }
+            },
+            "regexpu-core": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
+              }
+            }
+          }
+        },
+        "postcss-modules-scope": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "css-selector-tokenizer": "^0.6.0",
+            "postcss": "^5.0.4"
+          },
+          "dependencies": {
+            "css-selector-tokenizer": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "cssesc": "^0.1.0",
+                "fastparse": "^1.1.1",
+                "regexpu-core": "^1.0.0"
+              }
+            },
+            "regexpu-core": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
+              }
+            }
+          }
+        },
+        "postcss-modules-values": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "icss-replace-symbols": "^1.0.2",
+            "postcss": "^5.0.10"
+          }
+        },
+        "postcss-normalize-charset": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.5"
+          }
+        },
+        "postcss-normalize-url": {
+          "version": "3.0.7",
+          "bundled": true,
+          "requires": {
+            "is-absolute-url": "^2.0.0",
+            "normalize-url": "^1.4.0",
+            "postcss": "^5.0.14",
+            "postcss-value-parser": "^3.2.3"
+          }
+        },
+        "postcss-ordered-values": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.1"
+          }
+        },
+        "postcss-reduce-idents": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.2"
+          }
+        },
+        "postcss-reduce-initial": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.4"
+          }
+        },
+        "postcss-reduce-transforms": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.8",
+            "postcss-value-parser": "^3.0.1"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "flatten": "^1.0.2",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "postcss-svgo": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "is-svg": "^2.0.0",
+            "postcss": "^5.0.14",
+            "postcss-value-parser": "^3.2.3",
+            "svgo": "^0.6.1"
+          }
+        },
+        "postcss-unique-selectors": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "alphanum-sort": "^1.0.1",
+            "postcss": "^5.0.4",
+            "uniqs": "^2.0.0"
+          }
+        },
+        "postcss-value-parser": {
+          "version": "3.3.0",
+          "bundled": true
+        },
+        "postcss-zindex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "postcss": "^5.0.4",
+            "uniqs": "^2.0.0"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "pretty-error": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "renderkid": "~2.0.0",
+            "utila": "~0.4"
+          }
+        },
+        "private": {
+          "version": "0.1.6",
+          "bundled": true
+        },
+        "process": {
+          "version": "0.11.6",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "progress": {
+          "version": "1.1.8",
+          "bundled": true
+        },
+        "promise": {
+          "version": "7.1.1",
+          "bundled": true,
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        },
+        "proxy-addr": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "forwarded": "~0.1.0",
+            "ipaddr.js": "1.1.1"
+          }
+        },
+        "prr": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "q": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.2.0",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "4.2.2",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "querystringify": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "randomatic": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "is-number": "^2.0.2",
+            "kind-of": "^3.0.2"
+          }
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "readable-stream": "^2.0.2",
+            "set-immediate-shim": "^1.0.1"
+          }
+        },
+        "readline2": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "mute-stream": "0.0.5"
+          }
+        },
+        "reduce-css-calc": {
+          "version": "1.2.4",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^0.1.0",
+            "reduce-function-call": "^1.0.1"
+          },
+          "dependencies": {
+            "balanced-match": {
+              "version": "0.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "reduce-function-call": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "~0.1.0"
+          },
+          "dependencies": {
+            "balanced-match": {
+              "version": "0.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "regenerate": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "regenerator-runtime": {
+          "version": "0.9.5",
+          "bundled": true
+        },
+        "regex-cache": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "is-equal-shallow": "^0.1.3",
+            "is-primitive": "^2.0.0"
+          }
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        },
+        "relateurl": {
+          "version": "0.2.7",
+          "bundled": true
+        },
+        "renderkid": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "css-select": "^1.1.0",
+            "dom-converter": "~0.1",
+            "htmlparser2": "~3.3.0",
+            "strip-ansi": "^3.0.0",
+            "utila": "~0.3"
+          },
+          "dependencies": {
+            "utila": {
+              "version": "0.3.3",
+              "bundled": true
+            }
+          }
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.5.4",
+          "bundled": true
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "require-uncached": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
+          }
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "bundled": true
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "ripemd160": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "run-async": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0"
+          }
+        },
+        "rx-lite": {
+          "version": "3.1.2",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "send": {
+          "version": "0.14.1",
+          "bundled": true,
+          "requires": {
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
+            "fresh": "0.3.0",
+            "http-errors": "~1.5.0",
+            "mime": "1.3.4",
+            "ms": "0.7.1",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.3.0"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "1.3.4",
+              "bundled": true
+            }
+          }
+        },
+        "sentence-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case-first": "^1.1.2"
+          }
+        },
+        "serve-index": {
+          "version": "1.8.0",
+          "bundled": true,
+          "requires": {
+            "accepts": "~1.3.3",
+            "batch": "0.5.3",
+            "debug": "~2.2.0",
+            "escape-html": "~1.0.3",
+            "http-errors": "~1.5.0",
+            "mime-types": "~2.1.11",
+            "parseurl": "~1.3.1"
+          }
+        },
+        "serve-static": {
+          "version": "1.11.1",
+          "bundled": true,
+          "requires": {
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.1",
+            "send": "0.14.1"
+          }
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "setprototypeof": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "sha.js": {
+          "version": "2.2.6",
+          "bundled": true
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "shelljs": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "bundled": true
+        },
+        "snake-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "sockjs": {
+          "version": "0.3.17",
+          "bundled": true,
+          "requires": {
+            "faye-websocket": "^0.10.0",
+            "uuid": "^2.0.2"
+          }
+        },
+        "sockjs-client": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.2.0",
+            "eventsource": "~0.1.6",
+            "faye-websocket": "~0.11.0",
+            "inherits": "^2.0.1",
+            "json3": "^3.3.2",
+            "url-parse": "^1.1.1"
+          },
+          "dependencies": {
+            "faye-websocket": {
+              "version": "0.11.0",
+              "bundled": true,
+              "requires": {
+                "websocket-driver": ">=0.5.1"
+              }
+            }
+          }
+        },
+        "sort-keys": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        },
+        "source-list-map": {
+          "version": "0.1.6",
+          "bundled": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "bundled": true
+        },
+        "source-map-support": {
+          "version": "0.2.10",
+          "bundled": true,
+          "requires": {
+            "source-map": "0.1.32"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "bundled": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "statuses": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "stream-browserify": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "^1.0.27-1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "stream-cache": {
+          "version": "0.0.2",
+          "bundled": true
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "style-loader": {
+          "version": "0.13.1",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "^0.2.7"
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        },
+        "svgo": {
+          "version": "0.6.6",
+          "bundled": true,
+          "requires": {
+            "coa": "~1.0.1",
+            "colors": "~1.1.2",
+            "csso": "~2.0.0",
+            "js-yaml": "~3.6.0",
+            "mkdirp": "~0.5.1",
+            "sax": "~1.2.1",
+            "whet.extend": "~0.9.9"
+          }
+        },
+        "swap-case": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "lower-case": "^1.1.1",
+            "upper-case": "^1.1.1"
+          }
+        },
+        "table": {
+          "version": "3.7.8",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^3.1.1",
+            "chalk": "^1.1.1",
+            "lodash": "^4.0.0",
+            "slice-ansi": "0.0.4",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "tv4": "^1.2.7",
+            "xregexp": "^3.0.0"
+          }
+        },
+        "tapable": {
+          "version": "0.1.10",
+          "bundled": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "timers-browserify": {
+          "version": "1.4.2",
+          "bundled": true,
+          "requires": {
+            "process": "~0.11.0"
+          }
+        },
+        "title-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case": "^1.0.3"
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "toposort": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "tryit": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "tv4": {
+          "version": "1.2.7",
+          "bundled": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "type-is": {
+          "version": "1.6.13",
+          "bundled": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.1.11"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "uglify-js": {
+          "version": "2.6.4",
+          "bundled": true,
+          "requires": {
+            "async": "~0.2.6",
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "bundled": true
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uniq": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "uniqid": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "macaddress": "^0.2.8"
+          }
+        },
+        "uniqs": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "upper-case": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "upper-case-first": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "upper-case": "^1.1.1"
+          }
+        },
+        "url": {
+          "version": "0.10.3",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "bundled": true
+            }
+          }
+        },
+        "url-loader": {
+          "version": "0.5.7",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "0.2.x",
+            "mime": "1.2.x"
+          }
+        },
+        "url-parse": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "querystringify": "0.0.x",
+            "requires-port": "1.0.x"
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "utila": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "vary": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "vendors": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "bundled": true,
+          "requires": {
+            "indexof": "0.0.1"
+          }
+        },
+        "watchpack": {
+          "version": "0.2.9",
+          "bundled": true,
+          "requires": {
+            "async": "^0.9.0",
+            "chokidar": "^1.0.0",
+            "graceful-fs": "^4.1.2"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "bundled": true
+            }
+          }
+        },
+        "webpack": {
+          "version": "1.13.1",
+          "bundled": true,
+          "requires": {
+            "acorn": "^3.0.0",
+            "async": "^1.3.0",
+            "clone": "^1.0.2",
+            "enhanced-resolve": "~0.9.0",
+            "interpret": "^0.6.4",
+            "loader-utils": "^0.2.11",
+            "memory-fs": "~0.3.0",
+            "mkdirp": "~0.5.0",
+            "node-libs-browser": ">= 0.4.0 <=0.6.0",
+            "optimist": "~0.6.0",
+            "supports-color": "^3.1.0",
+            "tapable": "~0.1.8",
+            "uglify-js": "~2.6.0",
+            "watchpack": "^0.2.1",
+            "webpack-core": "~0.6.0"
+          }
+        },
+        "webpack-core": {
+          "version": "0.6.8",
+          "bundled": true,
+          "requires": {
+            "source-list-map": "~0.1.0",
+            "source-map": "~0.4.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "webpack-dev-middleware": {
+          "version": "1.6.1",
+          "bundled": true,
+          "requires": {
+            "memory-fs": "~0.3.0",
+            "mime": "^1.3.4",
+            "range-parser": "^1.0.3"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "1.3.4",
+              "bundled": true
+            }
+          }
+        },
+        "webpack-dev-server": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "compression": "^1.5.2",
+            "connect-history-api-fallback": "1.1.0",
+            "express": "^4.13.3",
+            "http-proxy": "^1.11.2",
+            "optimist": "~0.6.0",
+            "serve-index": "^1.7.2",
+            "sockjs": "^0.3.15",
+            "sockjs-client": "^1.0.3",
+            "stream-cache": "~0.0.1",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^3.1.1",
+            "webpack-dev-middleware": "^1.4.0"
+          }
+        },
+        "webpack-sources": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "source-list-map": "~0.1.0",
+            "source-map": "~0.5.3"
+          }
+        },
+        "websocket-driver": {
+          "version": "0.6.5",
+          "bundled": true,
+          "requires": {
+            "websocket-extensions": ">=0.1.1"
+          }
+        },
+        "websocket-extensions": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "whatwg-fetch": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "whet.extend": {
+          "version": "0.9.9",
+          "bundled": true
+        },
+        "which": {
+          "version": "1.2.10",
+          "bundled": true,
+          "requires": {
+            "isexe": "^1.1.1"
+          }
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "xml-char-classes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "xregexp": {
+          "version": "3.1.1",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "remarkable": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+      "integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
+      "requires": {
+        "argparse": "^1.0.10",
+        "autolinker": "~0.28.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "store2": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/store2/-/store2-2.12.0.tgz",
+      "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw=="
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "ua-parser-js": {
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+    },
+    "uncontrollable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz",
+      "integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=",
+      "requires": {
+        "invariant": "^2.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    }
+  }
+}


### PR DESCRIPTION
According to the [npm documentation](https://docs.npmjs.com/cli/v6/configuring-npm/package-lock-json), `package-lock.json` "is intended to be committed into source repositories". Having a `package-lock.json` file allows for automated tooling to report on outdated packages, including `npm audit` and [GitHub's Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/); we may get a wave of automated PRs upgrading the many many insecure dependencies we currently rely on.

Adding `package-lock.json` to source control is a first step to upgrading many of our dependencies, including React.

Issue #18 Upgrade React