### PR TITLE
Add explicit event argument to handler

### DIFF
--- a/src/components/AdminNicety.js
+++ b/src/components/AdminNicety.js
@@ -32,7 +32,7 @@ const AdminNicety = React.createClass({
         });
     },
 
-    textareaChange: function() {
+    textareaChange: function(event) {
         this.setState({ text: event.target.value , noSave: false });
     },
 


### PR DESCRIPTION
The onChange handler for `<AdminNicety>` was missing its event argument, and instead used the current event via the global event. This works, but is fairly surprising behavior, and a [future version of react-scripts](https://github.com/facebook/create-react-app/blob/master/CHANGELOG-1.x.md#confusing-window-globals-can-no-longer-be-used-without-window-qualifier) will stop the build on encountering a [no-restricted-globals](https://eslint.org/docs/rules/no-restricted-globals) linter error. The documentation for this error specifically calls this situation out:

> For instance, early Internet Explorer versions exposed the current DOM event as a global variable event, but using this variable has been considered as a bad practice for a long time. Restricting this will make sure this variable isn't used in browser code.

Add the event argument to the function definition, so that the variable referred to is the passed-in argument rather than the global.

Issue #18 Upgrade React