### PR TITLE
Upgrade psycopg2 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,15 @@ I built this using Python 3.6.13, node.js 14.15.5 and Postgres 12.6.
 2. Set up your Python virtual environment by running `pyvenv venv` in that directory and running `source venv/bin/activate` to active it.
 
 3. Install Python requirements with `pip install -r requirements.txt`.
+   You may need to install some [build
+   prerequisites](https://www.psycopg.org/docs/install.html#build-prerequisites);
+   on Debian-like systems, they include the packages `python3-dev` and
+   `libpq-dev`.
 
 4. Install the frontend requirements with `npm install`.
 
-5. Create an empty Postgres database, e.g. `createdb rcniceties`
+5. [Install PostgreSQL](https://www.postgresql.org/download/)
+   and create an empty database, e.g. `createdb rcniceties`
 
 6. Set the following environment variables, noting that the application **will not run** if any of these is not set:
     * `FLASK_APP` - the location of the app, e.g. `backend:app`

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Mako==1.1.4
 MarkupSafe==1.1.1
 oauthlib==2.1.0
 pip==18.1
-psycopg2==2.7.4
+psycopg2==2.8.6
 pyparsing==2.4.7
 python-dateutil==2.8.1
 python-editor==1.0.4


### PR DESCRIPTION
> Psycopg is the most popular PostgreSQL database adapter for the Python programming language. ([source](https://www.psycopg.org/docs/index.html))

Upgrade to the latest version of Psycopg2. This includes a somewhat large change in distribution, from the wheel (aka binary package) used previously to building from source. Building from source, in turn, leads to some [additional requirements](https://www.psycopg.org/docs/install.html#build-prerequisites):

> - A C compiler
> - The Python header files
> - The libpq header files
> - The `pg_config` program

I am a little hesitant to introduce such a wide set of dependencies, but the documentation explicitly warns against using the wheel (psycopg2-binary) in production:

> For production use you are advised to use the source distribution.

And, at the moment, we don't have separate Python dependencies for developers vs production.

Splitting out those dependencies, or adding more detailed instructions on how to install the binary package, are both valid alternative approaches to making this change. @mjec, @christalee, I'd be particularly interested to hear your thoughts on this!