### PR TITLE
Convert <Nicety> and <SaveButton> to function components

### DIFF
--- a/src/components/Nicety.js
+++ b/src/components/Nicety.js
@@ -3,32 +3,30 @@ import { Image } from 'react-bootstrap';
 
 import suittie from '../suittie.png';
 
-const Nicety = React.createClass({
-    render: function() {
-        let photo;
-        if (this.props.data.anonymous) {
-            photo = suittie;
-        } else {
-            photo = this.props.data.avatar_url;
-        }
-        let name;
-        if ('name' in this.props.data) {
-            name = this.props.data.name;
-        } else {
-            name = 'Anonymous';
-        }
-        return (
-            <div className="nicety">
-                <Image responsive={true} src={photo} circle={true} />
-                <h3>{name}</h3>
-                <textarea
-                    defaultValue={this.props.data.text}
-                    rows="6"
-                    readOnly
-                />
-            </div>
-        );
+const Nicety = (props) => {
+    let photo;
+    if (props.data.anonymous) {
+        photo = suittie;
+    } else {
+        photo = props.data.avatar_url;
     }
-})
+    let name;
+    if ('name' in props.data) {
+        name = props.data.name;
+    } else {
+        name = 'Anonymous';
+    }
+    return (
+        <div className="nicety">
+            <Image responsive={true} src={photo} circle={true} />
+            <h3>{name}</h3>
+            <textarea
+                defaultValue={props.data.text}
+                rows="6"
+                readOnly
+            />
+        </div>
+    );
+};
 
 export default Nicety;

--- a/src/components/SaveButton.js
+++ b/src/components/SaveButton.js
@@ -1,29 +1,17 @@
 import React from 'react';
 import { Button } from 'react-bootstrap';
 
-const SaveButton = React.createClass({
-    render: function() {
-        if (this.props.noSave === true) {
-            return (
-                <div className="button">
-                    <Button
-                    bsStyle="primary"
-                    bsSize="large"
-                    disabled
-                    >Save</Button>
-                </div>
-            );
-        } else {
-            return (
-                <div className="button">
-                    <Button
-                    bsStyle="primary"
-                    bsSize="large"
-                    onClick={this.props.onClick}>Save</Button>
-                </div>
-            );
-        }
-    }
-});
+const SaveButton = (props) => (
+    <div className="button">
+        <Button
+            bsStyle="primary"
+            bsSize="large"
+            disabled={props.noSave === true}
+            onClick={props.onClick}
+        >
+            Save
+        </Button>
+    </div>
+);
 
 export default SaveButton;


### PR DESCRIPTION
The `React.createClass` method of creating React components was deprecated with [React 15.5.0](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactcreateclass). We will need to convert each component away from using `createClass`. There were a few alternatives at the time, including the recommendation they gave then of `class Example extends React.Component`; however, the current preferred trend is function components.

Function components were introduced with [React 0.14](https://reactjs.org/blog/2015/10/07/react-v0.14.html#stateless-function-components), and work great when the entirety of a component is its render method. (Later versions of React support function components with state and side effects via [hooks](https://reactjs.org/blog/2019/02/06/react-v16.8.0.html), but we're not there yet!)

`<Nicety>` and `<SaveButton>` are two of our leaf components, which makes them ideal components for this kind of conversion: they depend on no other internal components, have no state, and have no behavior. Convert them each to be a function component.

See the individual commit messages for slightly more detail.

To test, build the frontend and reload the site, then verify that the save button works as expected, and the "Niceties for me" displays niceties. If you have the [React dev tools plugin](https://github.com/facebook/react/tree/master/packages/react-devtools) installed, you can tell that these components were converted by examining the component tree: they should now have minified names in the production build, like `s` or `t`, rather than their full names.