### PR TITLE
Convert <NicetyDisplay> to function component

### DIFF
--- a/src/components/NicetyDisplay.js
+++ b/src/components/NicetyDisplay.js
@@ -3,26 +3,26 @@ import { Grid } from 'react-bootstrap';
 
 import NicetyRow from './NicetyRow';
 
-const NicetyDisplay = React.createClass({
-    generateRows: function() {
-        let dataList = [];
-        for (let i = 0; i < this.props.niceties.length; i +=4) {
-            let row = [];
-            for (let j = 0; j < 4; j++) {
-                if ((i + j) < this.props.niceties.length) {
-                    row.push(this.props.niceties[i + j]);
-                }
+const generateRows = (input) => {
+    let dataList = [];
+    for (let i = 0; i < input.length; i +=4) {
+        let row = [];
+        for (let j = 0; j < 4; j++) {
+            if ((i + j) < input.length) {
+                row.push(input[i + j]);
             }
-            dataList.push(row);
         }
-        return dataList;
-    },
+        dataList.push(row);
+    }
+    return dataList;
+};
 
+const NicetyDisplay = React.createClass({
     render: function() {
         return (
             <div className="niceties">
                 <Grid>
-                    {this.generateRows().map((row) => <NicetyRow data={row}/>)}
+                    {generateRows(this.props.niceties).map((row) => <NicetyRow data={row}/>)}
                 </Grid>
             </div>
         );}

--- a/src/components/NicetyDisplay.js
+++ b/src/components/NicetyDisplay.js
@@ -17,15 +17,12 @@ const generateRows = (input) => {
     return dataList;
 };
 
-const NicetyDisplay = React.createClass({
-    render: function() {
-        return (
-            <div className="niceties">
-                <Grid>
-                    {generateRows(this.props.niceties).map((row) => <NicetyRow data={row}/>)}
-                </Grid>
-            </div>
-        );}
-});
+const NicetyDisplay = (props) => (
+    <div className="niceties">
+        <Grid>
+            {generateRows(props.niceties).map((row) => <NicetyRow data={row}/>)}
+        </Grid>
+    </div>
+);
 
 export default NicetyDisplay;

--- a/src/components/NicetyDisplay.js
+++ b/src/components/NicetyDisplay.js
@@ -4,13 +4,6 @@ import { Grid } from 'react-bootstrap';
 import NicetyRow from './NicetyRow';
 
 const NicetyDisplay = React.createClass({
-
-    getInitialState: function() {
-        return {
-            niceties: []
-        };
-    },
-
     generateRows: function() {
         let dataList = [];
         for (let i = 0; i < this.props.niceties.length; i +=4) {

--- a/src/components/NicetyDisplay.js
+++ b/src/components/NicetyDisplay.js
@@ -19,11 +19,10 @@ const NicetyDisplay = React.createClass({
     },
 
     render: function() {
-        let list = this.generateRows();
         return (
             <div className="niceties">
                 <Grid>
-                    {list.map((row) => (<NicetyRow data={row}/>)}
+                    {this.generateRows().map((row) => <NicetyRow data={row}/>)}
                 </Grid>
             </div>
         );}

--- a/src/components/NicetyDisplay.js
+++ b/src/components/NicetyDisplay.js
@@ -22,14 +22,10 @@ const NicetyDisplay = React.createClass({
         let list = this.generateRows();
         return (
             <div className="niceties">
-              <Grid>
-                {list.map(function(row) {
-                    return (
-                        <NicetyRow data={row}/>
-                    );
-                })}
-            </Grid>
-                </div>
+                <Grid>
+                    {list.map((row) => (<NicetyRow data={row}/>)}
+                </Grid>
+            </div>
         );}
 });
 


### PR DESCRIPTION
The `React.createClass` method of creating components was deprecated with React 15.5.0. Refactor the `<NicetyDisplay>` component to be a React function component, with several cleanup steps along the way. See the individual commit messages for more details.

Issue #18 Upgrade React