### PR TITLE
Remove hard-coded "special" people

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -306,23 +306,18 @@ def display_people():
             leaving.append(person)
     staying = list(person for person in people['staying'])
     faculty = get_current_faculty()
-    # there needs to be a better way to add special people to the current exiting batch
-    special = [x for x in faculty if x['id'] == 601]
     random.seed(current_user().random_seed)
     random.shuffle(staying)
     random.shuffle(leaving)
-    random.shuffle(special)
     if current_user_leaving is True:
         to_display = {
             'staying': staying,
             'leaving': leaving,
-            'special': special,
             'faculty': faculty
         }
     else:
         to_display = {
             'leaving': leaving,
-            'special': special,
             'faculty': faculty
         }
 

--- a/src/components/People.js
+++ b/src/components/People.js
@@ -108,7 +108,6 @@ const People = React.createClass({
     render: function() {
         let leaving = this.generateRows(this.props.people.leaving);
         let staying = this.generateRows(this.props.people.staying);
-        let special = this.generateRows(this.props.people.special);
         let faculty = this.generateRows(this.props.people.faculty);
         const savePass = this.saveReady.bind(this);
 
@@ -124,12 +123,6 @@ const People = React.createClass({
 
         let staffHeader;
         let staffRows;
-        //if (staying.length > 0) {
-            // staffRows = special.map(function(row) {
-            //     return (
-            //         <PeopleRow fromMe={this.props.fromMe} data={row} saveReady={savePass}/>
-            //     );
-            // }.bind(this))
             staffRows = faculty.map(function(row) {
                 return (
                     <PeopleRow fromMe={this.props.fromMe} data={row} saveReady={savePass} updated_niceties={this.state.updated_niceties}/>
@@ -140,7 +133,6 @@ const People = React.createClass({
                 <h3>Staff</h3>
 
             );
-        //}
         return (
             <div className="people">
               <Modal show={this.state.justSaved}>

--- a/src/components/People.js
+++ b/src/components/People.js
@@ -121,18 +121,6 @@ const People = React.createClass({
             this.alertTimer();
         }
 
-        let staffHeader;
-        let staffRows;
-            staffRows = faculty.map(function(row) {
-                return (
-                    <PeopleRow fromMe={this.props.fromMe} data={row} saveReady={savePass} updated_niceties={this.state.updated_niceties}/>
-                );
-            }.bind(this))
-
-            staffHeader = (
-                <h3>Staff</h3>
-
-            );
         return (
             <div className="people">
               <Modal show={this.state.justSaved}>
@@ -163,8 +151,17 @@ const People = React.createClass({
                   );
                 }.bind(this))}
                 { maybeHR }
-                { staffHeader }
-                { staffRows }
+
+                <h3>Staff</h3>
+                {faculty.map((row) => (
+                    <PeopleRow
+                        fromMe={this.props.fromMe}
+                        data={row}
+                        saveReady={savePass}
+                        updated_niceties={this.state.updated_niceties}
+                    />
+                ))}
+
               </Grid>
               <div className="save_button">
                 <SaveButton


### PR DESCRIPTION
The Niceties app's concept of "special" people is based on an out-of-date assumption: that we should only show faculty members that are leaving soon. Since the staff stopped using the Niceties app, they've been including all faculty members in the Google form.

(It is also based on the assumption that the RC API would not give departing faculty members' end date; I'm not sure if that is still the case.)

We want Niceties to always show faculty, and we started doing so in commit PR #30. That PR also commented out the client-side handling of "special" people, so even if we were populating that field in the API, the client would not show it.

Remove the "special" field in the API, delete the commented-out front-end code that used it, and clean up the front-end code around displaying faculty.