### PR TITLE
Add display logic to show placeholder text based on profile interests

### DIFF
--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -146,6 +146,7 @@ const Person = React.createClass({
                 defaultValue={this.state.textValue}
                 onChange={this.textareaChange}
                 rows="6"
+                placeholder={this.props.data.placeholder}
             />
             {anonymousRender}
             {noReadRender}


### PR DESCRIPTION
The data was included in a long-ago commit, but somehow I never included the corresponding front-end logic to actually show placeholder text. 

Currently it pulls the user's interests from their RC profile but more elaborate options include: a list of events they've hosted (would need to integrate with the Calendar) or github repos (the code for this exists but throws an error).