### PR TITLE
Remove empty componentDidMount from <Person>

### DIFF
--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -100,10 +100,6 @@ const Person = React.createClass({
 
     // TODO: button for each person for anonymous option
 
-    componentDidMount: function() {
-        // setInterval(this.autosave, this.props.autosaveInterval);
-    },
-
     // hold a callback in the parent and pass it to the child as a prop that gets called in onChange
     // this callback would have the parent update its own min/max rows and pass this to all children
     // but it seems like for this to work you need child.state.height (to figureo ut the new min rows)


### PR DESCRIPTION
The [`componentDidMount` function](https://reactjs.org/docs/react-component.html#componentdidmount) is part of the React lifecycle:

> `componentDidMount()` is invoked immediately after a component is mounted (inserted into the tree). Initialization that requires DOM nodes should go here.

Once upon a time, `<Person>` had some autosave functionality that was initialized in `componentDidMount`, but it was removed in commit a40a1e9015286d6cca1ac171277993036336a2b7.

Delete the now-empty function both for the sake of simplifying the code, and to reduce the number of changes needed to convert from `React.createClass` to `React.Component`.

Issue #18 Upgrade React