### PR TITLE
Convert <NicetyRow> and <PeopleRow> to functional components

### DIFF
--- a/src/components/NicetyRow.js
+++ b/src/components/NicetyRow.js
@@ -3,18 +3,14 @@ import { Row, Col } from 'react-bootstrap';
 
 import Nicety from './Nicety';
 
-const NicetyRow = React.createClass({
-    render: function() {
-        return (
-            <Row>
-                {this.props.data.map((result) => (
-                    <Col lg="3" md="6" sm="6" xs="12">
-                        <Nicety data={result}/>
-                    </Col>
-                ))}
-            </Row>
-        );
-    }
-});
+const NicetyRow = (props) => (
+    <Row>
+        {props.data.map((result) => (
+            <Col lg="3" md="6" sm="6" xs="12">
+                <Nicety data={result}/>
+            </Col>
+        ))}
+    </Row>
+);
 
 export default NicetyRow;

--- a/src/components/NicetyRow.js
+++ b/src/components/NicetyRow.js
@@ -7,12 +7,11 @@ const NicetyRow = React.createClass({
     render: function() {
         return (
             <Row>
-              {this.props.data
-                  .map(function(result) {
-                      return (<Col lg="3" md="6" sm="6" xs="12">
-                              <Nicety data={result}/>
-                              </Col>);
-                  })}
+                {this.props.data.map((result) => (
+                    <Col lg="3" md="6" sm="6" xs="12">
+                        <Nicety data={result}/>
+                    </Col>
+                ))}
             </Row>
         );
     }

--- a/src/components/PeopleRow.js
+++ b/src/components/PeopleRow.js
@@ -3,24 +3,20 @@ import { Row, Col } from 'react-bootstrap';
 
 import Person from "./Person";
 
-const PeopleRow = React.createClass({
-    render: function() {
-        return (
-            <Row>
-                {this.props.data.map((result) => (
-                    <Col lg="3" md="6" sm="6" xs="12">
-                        <Person
-                            fromMe={this.props.fromMe}
-                            data={result}
-                            saveReady={this.props.saveReady}
-                            saveButton={this.props.saveButton}
-                            updated_niceties={this.props.updated_niceties}
-                        />
-                    </Col>
-                ))}
-            </Row>
-        );
-    }
-});
+const PeopleRow = (props) => (
+    <Row>
+        {props.data.map((result) => (
+            <Col lg="3" md="6" sm="6" xs="12">
+                <Person
+                    fromMe={props.fromMe}
+                    data={result}
+                    saveReady={props.saveReady}
+                    saveButton={props.saveButton}
+                    updated_niceties={props.updated_niceties}
+                />
+            </Col>
+        ))}
+    </Row>
+);
 
 export default PeopleRow;

--- a/src/components/PeopleRow.js
+++ b/src/components/PeopleRow.js
@@ -5,7 +5,6 @@ import Person from "./Person";
 
 const PeopleRow = React.createClass({
     render: function() {
-        const saveButton = this.props.saveButton;
         return (
             <Row>
                 {this.props.data.map((result) => (
@@ -14,7 +13,7 @@ const PeopleRow = React.createClass({
                             fromMe={this.props.fromMe}
                             data={result}
                             saveReady={this.props.saveReady}
-                            saveButton={saveButton}
+                            saveButton={this.props.saveButton}
                             updated_niceties={this.props.updated_niceties}
                         />
                     </Col>

--- a/src/components/PeopleRow.js
+++ b/src/components/PeopleRow.js
@@ -8,12 +8,17 @@ const PeopleRow = React.createClass({
         const saveButton = this.props.saveButton;
         return (
             <Row>
-              {this.props.data
-                .map(function(result) {
-                  return (<Col lg="3" md="6" sm="6" xs="12">
-                    <Person fromMe={this.props.fromMe} data={result} saveReady={this.props.saveReady} saveButton={saveButton} updated_niceties={this.props.updated_niceties}/>
-                  </Col>);
-                }.bind(this))}
+                {this.props.data.map((result) => (
+                    <Col lg="3" md="6" sm="6" xs="12">
+                        <Person
+                            fromMe={this.props.fromMe}
+                            data={result}
+                            saveReady={this.props.saveReady}
+                            saveButton={saveButton}
+                            updated_niceties={this.props.updated_niceties}
+                        />
+                    </Col>
+                ))}
             </Row>
         );
     }


### PR DESCRIPTION
The `React.createClass` method of creating React components was [deprecated with React 15.5.0](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactcreateclass). We will need to convert each component away from using `createClass`. There were a few alternatives at the time, including the recommendation they gave then of `class Example extends React.Component`; however, the current preferred trend is function components.

[Function components were introduced with React 0.14](https://reactjs.org/blog/2015/10/07/react-v0.14.html#stateless-function-components), and work great when the entirety of a component is its render method. (Later versions of React support function components with state and side effects via [hooks](https://reactjs.org/blog/2019/02/06/react-v16.8.0.html), but we're not there yet!)

`<NicetyRow>` and `<PeopleRow>` are two of our simpler components, which makes them ideal for this kind of conversion: they have no state, and no behavior. After a few refactoring steps, convert each to be a function component.

Issue #18 Upgrade React
