### PR TITLE
convert Person to ES6

### DIFF
--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -1,140 +1,140 @@
 import React from 'react';
-import {Checkbox, Image,} from 'react-bootstrap';
+import {Checkbox, Image} from 'react-bootstrap';
 import store from 'store2';
 
 import {updated_niceties_spinlock} from "./People";
 
 class Person extends React.Component {
-  constructor(props) {
-    super(props)
-    let textValue = '';
-    let anonValue = false;
-    let noReadValue = false;
-    let dataPerson;
-    let foundPerson = false;
-    for (var i = 0; i < props.fromMe.length; i++) {
-      if (props.fromMe[i].target_id === props.data.id) {
-        dataPerson = props.fromMe[i];
-        foundPerson = true;
-        break;
-      }
-    }
-    let dateUpdated;
-    if (foundPerson) {
-      if (dataPerson.date_updated === null) {
-        dateUpdated = '';
-      } else {
-        dateUpdated = dataPerson.date_updated;
-      }
-    }
-    if (foundPerson && store.get("date_updated-" + props.data.id) === null) {
-      if (dataPerson.text !== '' && dataPerson.text !== null) {
-        store.set("nicety-" + props.data.id, dataPerson.text);
-        textValue = dataPerson.text;
-      } else {
-        textValue = '';
-      }
-      store.set("anonymous-" + props.data.id, dataPerson.anonymous);
-      anonValue = dataPerson.anonymous;
-      store.set("no_read-" + props.data.id, dataPerson.no_read);
-      noReadValue = dataPerson.no_read;
-      store.set("date_updated-" + props.data.id, dateUpdated);
-    } else if (foundPerson && store.get("date_updated-" + props.data.id) !== dateUpdated) {
-      if (dataPerson.text !== '' && dataPerson.text !== null) {
-        store.set("nicety-" + props.data.id, dataPerson.text);
-        textValue = dataPerson.text;
-      } else {
-        textValue = '';
-      }
-      store.set("anonymous-" + props.data.id, dataPerson.anonymous);
-      anonValue = dataPerson.anonymous;
-      store.set("no_read-" + props.data.id, dataPerson.no_read);
-      noReadValue = dataPerson.no_read;
-      store.set("date_updated-" + props.data.id, dateUpdated);
-    } else {
-      if (store.get("nicety-" + props.data.id) !== null) {
-        textValue = store.get("nicety-" + props.data.id);
-      }
-      if (store.get("anonymous-" + props.data.id) !== null) {
-        anonValue = store.get("anonymous-" + props.data.id);
-      }
-      if (store.get("no_read-" + props.data.id) !== null) {
-        noReadValue = store.get("no_read-" + props.data.id);
-      }
+    constructor(props) {
+        super(props)
+        let textValue = '';
+        let anonValue = false;
+        let noReadValue = false;
+        let dataPerson;
+        let foundPerson = false;
+        for (var i = 0; i < props.fromMe.length; i++) {
+            if (props.fromMe[i].target_id === props.data.id) {
+                dataPerson = props.fromMe[i];
+                foundPerson = true;
+                break;
+            }
+        }
+        let dateUpdated;
+        if (foundPerson) {
+            if (dataPerson.date_updated === null) {
+                dateUpdated = '';
+            } else {
+                dateUpdated = dataPerson.date_updated;
+            }
+        }
+        if (foundPerson && store.get("date_updated-" + props.data.id) === null) {
+            if (dataPerson.text !== '' && dataPerson.text !== null) {
+                store.set("nicety-" + props.data.id, dataPerson.text);
+                textValue = dataPerson.text;
+            } else {
+                textValue = '';
+            }
+            store.set("anonymous-" + props.data.id, dataPerson.anonymous);
+            anonValue = dataPerson.anonymous;
+            store.set("no_read-" + props.data.id, dataPerson.no_read);
+            noReadValue = dataPerson.no_read;
+            store.set("date_updated-" + props.data.id, dateUpdated);
+        } else if (foundPerson && store.get("date_updated-" + props.data.id) !== dateUpdated) {
+            if (dataPerson.text !== '' && dataPerson.text !== null) {
+                store.set("nicety-" + props.data.id, dataPerson.text);
+                textValue = dataPerson.text;
+            } else {
+                textValue = '';
+            }
+            store.set("anonymous-" + props.data.id, dataPerson.anonymous);
+            anonValue = dataPerson.anonymous;
+            store.set("no_read-" + props.data.id, dataPerson.no_read);
+            noReadValue = dataPerson.no_read;
+            store.set("date_updated-" + props.data.id, dateUpdated);
+        } else {
+            if (store.get("nicety-" + props.data.id) !== null) {
+                textValue = store.get("nicety-" + props.data.id);
+            }
+            if (store.get("anonymous-" + props.data.id) !== null) {
+                anonValue = store.get("anonymous-" + props.data.id);
+            }
+            if (store.get("no_read-" + props.data.id) !== null) {
+                noReadValue = store.get("no_read-" + props.data.id);
+            }
+        }
+
+        this.state = {
+            textValue: textValue,
+            anonValue: anonValue,
+            noReadValue: noReadValue,
+        }
     }
 
-    this.state = {
-      textValue: textValue,
-      anonValue: anonValue,
-      noReadValue: noReadValue
+    updateSave = () => {
+        while (updated_niceties_spinlock) {}
+        let addString;
+        if (this.props.data.stints.length > 0) {
+            addString = this.props.data.id + "," + this
+                .props
+                .data
+                .stints[this.props.data.stints.length - 1]
+                .end_date;
+        } else {
+            addString = this.props.data.id + ",2016-11-03";
+        }
+        if (!(addString in this.props.updated_niceties)) {
+            this
+                .props
+                .updated_niceties
+                .add(addString);
+        }
+        store.set("saved", false);
+        this
+            .props
+            .saveReady();
     }
-  }
 
-  updateSave = () => {
-    while (updated_niceties_spinlock) {}
-    let addString;
-    if (this.props.data.stints.length > 0) {
-      addString = this.props.data.id + "," + this
-        .props
-        .data
-        .stints[this.props.data.stints.length - 1]
-        .end_date;
-    } else {
-      addString = this.props.data.id + ",2016-11-03";
+    textareaChange = (event) => {
+        this.setState({textValue: event.target.value});
+        store.set("nicety-" + this.props.data.id, event.target.value);
+        this.updateSave();
     }
-    if (!(addString in this.props.updated_niceties)) {
-      this
-        .props
-        .updated_niceties
-        .add(addString);
+
+    anonymousChange = (event) => {
+        this.setState({anonValue: event.target.checked});
+        store.set("anonymous-" + this.props.data.id, event.target.checked);
+        this.updateSave();
     }
-    store.set("saved", false);
-    this
-      .props
-      .saveReady();
-  }
 
-  textareaChange = (event) => {
-    this.setState({textValue: event.target.value});
-    store.set("nicety-" + this.props.data.id, event.target.value);
-    this.updateSave();
-  }
+    noReadChange = (event) => {
+        this.setState({noReadValue: event.target.checked});
+        store.set("no_read-" + this.props.data.id, event.target.checked);
+        this.updateSave();
+    }
 
-  anonymousChange = (event) => {
-    this.setState({anonValue: event.target.checked});
-    store.set("anonymous-" + this.props.data.id, event.target.checked);
-    this.updateSave();
-  }
-
-  noReadChange = (event) => {
-    this.setState({noReadValue: event.target.checked});
-    store.set("no_read-" + this.props.data.id, event.target.checked);
-    this.updateSave();
-  }
-
-  render() {
-    return (
-      <div className="person">
-        <Image responsive={true} src={this.props.data.avatar_url} circle={true}/>
-        <h3>{this.props.data.name}</h3>
-        <textarea
-          defaultValue={this.state.textValue}
-          onChange={this.textareaChange}
-          rows="6"
-          placeholder={this.props.data.placeholder}/>
-        <Checkbox
-          checked={this.state.anonValue === true}
-          onChange={this.anonymousChange}>
-          Submit Anonymously
-        </Checkbox>
-        <Checkbox
-          checked={this.state.noReadValue === true}
-          onChange={this.noReadChange}>
-          Don't Read At Ceremony
-        </Checkbox>
-      </div>
-    );
-  }
+    render() {
+        return (
+            <div className="person">
+                <Image responsive={true} src={this.props.data.avatar_url} circle={true}/>
+                <h3>{this.props.data.name}</h3>
+                <textarea
+                    defaultValue={this.state.textValue}
+                    onChange={this.textareaChange}
+                    rows="6"
+                    placeholder={this.props.data.placeholder}/>
+                <Checkbox
+                    checked={this.state.anonValue === true}
+                    onChange={this.anonymousChange}>
+                    Submit Anonymously
+                </Checkbox>
+                <Checkbox
+                    checked={this.state.noReadValue === true}
+                    onChange={this.noReadChange}>
+                    Don't Read At Ceremony
+                </Checkbox>
+            </div>
+        );
+    }
 }
 
 export default Person;

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Checkbox, Image } from 'react-bootstrap';
+import {Checkbox, Image,} from 'react-bootstrap';
 import store from 'store2';
 
-import { updated_niceties_spinlock } from "./People";
-
+import {updated_niceties_spinlock} from "./People";
 
 class Person extends React.Component {
   constructor(props) {
@@ -14,60 +13,60 @@ class Person extends React.Component {
     let dataPerson;
     let foundPerson = false;
     for (var i = 0; i < props.fromMe.length; i++) {
-        if (props.fromMe[i].target_id === props.data.id) {
-            dataPerson = props.fromMe[i];
-            foundPerson = true;
-            break;
-        }
+      if (props.fromMe[i].target_id === props.data.id) {
+        dataPerson = props.fromMe[i];
+        foundPerson = true;
+        break;
+      }
     }
     let dateUpdated;
     if (foundPerson) {
-        if (dataPerson.date_updated === null) {
-            dateUpdated = '';
-        } else {
-            dateUpdated = dataPerson.date_updated;
-        }
+      if (dataPerson.date_updated === null) {
+        dateUpdated = '';
+      } else {
+        dateUpdated = dataPerson.date_updated;
+      }
     }
     if (foundPerson && store.get("date_updated-" + props.data.id) === null) {
-        if (dataPerson.text !== '' && dataPerson.text !== null) {
-            store.set("nicety-" + props.data.id, dataPerson.text);
-            textValue = dataPerson.text;
-        } else {
-            textValue = '';
-        }
-        store.set("anonymous-" + props.data.id, dataPerson.anonymous);
-        anonValue = dataPerson.anonymous;
-        store.set("no_read-" + props.data.id, dataPerson.no_read);
-        noReadValue = dataPerson.no_read;
-        store.set("date_updated-" + props.data.id, dateUpdated);
+      if (dataPerson.text !== '' && dataPerson.text !== null) {
+        store.set("nicety-" + props.data.id, dataPerson.text);
+        textValue = dataPerson.text;
+      } else {
+        textValue = '';
+      }
+      store.set("anonymous-" + props.data.id, dataPerson.anonymous);
+      anonValue = dataPerson.anonymous;
+      store.set("no_read-" + props.data.id, dataPerson.no_read);
+      noReadValue = dataPerson.no_read;
+      store.set("date_updated-" + props.data.id, dateUpdated);
     } else if (foundPerson && store.get("date_updated-" + props.data.id) !== dateUpdated) {
-        if (dataPerson.text !== '' && dataPerson.text !== null) {
-            store.set("nicety-" + props.data.id, dataPerson.text);
-            textValue = dataPerson.text;
-        } else {
-            textValue = '';
-        }
-        store.set("anonymous-" + props.data.id, dataPerson.anonymous);
-        anonValue = dataPerson.anonymous;
-        store.set("no_read-" + props.data.id, dataPerson.no_read);
-        noReadValue = dataPerson.no_read;
-        store.set("date_updated-" + props.data.id, dateUpdated);
+      if (dataPerson.text !== '' && dataPerson.text !== null) {
+        store.set("nicety-" + props.data.id, dataPerson.text);
+        textValue = dataPerson.text;
+      } else {
+        textValue = '';
+      }
+      store.set("anonymous-" + props.data.id, dataPerson.anonymous);
+      anonValue = dataPerson.anonymous;
+      store.set("no_read-" + props.data.id, dataPerson.no_read);
+      noReadValue = dataPerson.no_read;
+      store.set("date_updated-" + props.data.id, dateUpdated);
     } else {
-        if (store.get("nicety-" + props.data.id) !== null) {
-            textValue = store.get("nicety-" + props.data.id);
-        }
-        if (store.get("anonymous-" + props.data.id) !== null) {
-            anonValue = store.get("anonymous-" + props.data.id);
-        }
-        if (store.get("no_read-" + props.data.id) !== null) {
-            noReadValue = store.get("no_read-" + props.data.id);
-        }
+      if (store.get("nicety-" + props.data.id) !== null) {
+        textValue = store.get("nicety-" + props.data.id);
+      }
+      if (store.get("anonymous-" + props.data.id) !== null) {
+        anonValue = store.get("anonymous-" + props.data.id);
+      }
+      if (store.get("no_read-" + props.data.id) !== null) {
+        noReadValue = store.get("no_read-" + props.data.id);
+      }
     }
 
     this.state = {
       textValue: textValue,
       anonValue: anonValue,
-      noReadValue: noReadValue,
+      noReadValue: noReadValue
     }
   }
 
@@ -75,15 +74,24 @@ class Person extends React.Component {
     while (updated_niceties_spinlock) {}
     let addString;
     if (this.props.data.stints.length > 0) {
-        addString = this.props.data.id + "," + this.props.data.stints[this.props.data.stints.length - 1].end_date;
+      addString = this.props.data.id + "," + this
+        .props
+        .data
+        .stints[this.props.data.stints.length - 1]
+        .end_date;
     } else {
-        addString = this.props.data.id + ",2016-11-03";
+      addString = this.props.data.id + ",2016-11-03";
     }
     if (!(addString in this.props.updated_niceties)) {
-        this.props.updated_niceties.add(addString);
+      this
+        .props
+        .updated_niceties
+        .add(addString);
     }
     store.set("saved", false);
-    this.props.saveReady();
+    this
+      .props
+      .saveReady();
   }
 
   textareaChange = (event) => {
@@ -106,24 +114,25 @@ class Person extends React.Component {
 
   render() {
     return (
-        <div className="person">
-            <Image responsive={true} src={this.props.data.avatar_url} circle={true} />
-            <h3>{this.props.data.name}</h3>
+      <div className="person">
+        <Image responsive={true} src={this.props.data.avatar_url} circle={true}/>
+        <h3>{this.props.data.name}</h3>
         <textarea
-            defaultValue={this.state.textValue}
-            onChange={this.textareaChange}
-            rows="6"
-            placeholder={this.props.data.placeholder}
-        />
-        <Checkbox checked={this.state.anonValue === true}
+          defaultValue={this.state.textValue}
+          onChange={this.textareaChange}
+          rows="6"
+          placeholder={this.props.data.placeholder}/>
+        <Checkbox
+          checked={this.state.anonValue === true}
           onChange={this.anonymousChange}>
-            Submit Anonymously
+          Submit Anonymously
         </Checkbox>
-        <Checkbox checked={this.state.noReadValue === true}
+        <Checkbox
+          checked={this.state.noReadValue === true}
           onChange={this.noReadChange}>
-            Don't Read At Ceremony
+          Don't Read At Ceremony
         </Checkbox>
-        </div>
+      </div>
     );
   }
 }

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -82,9 +82,7 @@ class Person extends React.Component {
             this.props.updated_niceties.add(addString);
         }
         store.set("saved", false);
-        this
-            .props
-            .saveReady();
+        this.props.saveReady();
     }
 
     textareaChange = (event) => {

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -74,19 +74,12 @@ class Person extends React.Component {
         while (updated_niceties_spinlock) {}
         let addString;
         if (this.props.data.stints.length > 0) {
-            addString = this.props.data.id + "," + this
-                .props
-                .data
-                .stints[this.props.data.stints.length - 1]
-                .end_date;
+            addString = this.props.data.id + "," + this.props.data.stints[this.props.data.stints.length - 1].end_date;
         } else {
             addString = this.props.data.id + ",2016-11-03";
         }
         if (!(addString in this.props.updated_niceties)) {
-            this
-                .props
-                .updated_niceties
-                .add(addString);
+            this.props.updated_niceties.add(addString);
         }
         store.set("saved", false);
         this

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -5,150 +5,127 @@ import store from 'store2';
 import { updated_niceties_spinlock } from "./People";
 
 
-const Person = React.createClass({
-    getInitialState: function() {
-        let textValue = '';
-        let anonValue = false;
-        let noReadValue = false;
-        let dataPerson;
-        let foundPerson = false;
-        for (var i = 0; i < this.props.fromMe.length; i++) {
-            if (this.props.fromMe[i].target_id === this.props.data.id) {
-                dataPerson = this.props.fromMe[i];
-                foundPerson = true;
-                break;
-            }
+class Person extends React.Component {
+  constructor(props) {
+    super(props)
+    let textValue = '';
+    let anonValue = false;
+    let noReadValue = false;
+    let dataPerson;
+    let foundPerson = false;
+    for (var i = 0; i < props.fromMe.length; i++) {
+        if (props.fromMe[i].target_id === props.data.id) {
+            dataPerson = props.fromMe[i];
+            foundPerson = true;
+            break;
         }
-        let dateUpdated;
-        if (foundPerson) {
-            if (dataPerson.date_updated === null) {
-                dateUpdated = '';
-            } else {
-                dateUpdated = dataPerson.date_updated;
-            }
-        }
-        if (foundPerson && store.get("date_updated-" + this.props.data.id) === null) {
-            if (dataPerson.text !== '' && dataPerson.text !== null) {
-                store.set("nicety-" + this.props.data.id, dataPerson.text);
-                textValue = dataPerson.text;
-            } else {
-                textValue = '';
-            }
-            store.set("anonymous-" + this.props.data.id, dataPerson.anonymous);
-            anonValue = dataPerson.anonymous;
-            store.set("no_read-" + this.props.data.id, dataPerson.no_read);
-            noReadValue = dataPerson.no_read;
-            store.set("date_updated-" + this.props.data.id, dateUpdated);
-        } else if (foundPerson && store.get("date_updated-" + this.props.data.id) !== dateUpdated) {
-            if (dataPerson.text !== '' && dataPerson.text !== null) {
-                store.set("nicety-" + this.props.data.id, dataPerson.text);
-                textValue = dataPerson.text;
-            } else {
-                textValue = '';
-            }
-            store.set("anonymous-" + this.props.data.id, dataPerson.anonymous);
-            anonValue = dataPerson.anonymous;
-            store.set("no_read-" + this.props.data.id, dataPerson.no_read);
-            noReadValue = dataPerson.no_read;
-            store.set("date_updated-" + this.props.data.id, dateUpdated);
-        } else {
-            if (store.get("nicety-" + this.props.data.id) !== null) {
-                textValue = store.get("nicety-" + this.props.data.id);
-            }
-            if (store.get("anonymous-" + this.props.data.id) !== null) {
-                anonValue = store.get("anonymous-" + this.props.data.id);
-            }
-            if (store.get("no_read-" + this.props.data.id) !== null) {
-                noReadValue = store.get("no_read-" + this.props.data.id);
-            }
-        }
-        return {
-            textValue: textValue,
-            anonValue: anonValue,
-            noReadValue: noReadValue,
-        }
-    },
-    updateSave: function() {
-        while (updated_niceties_spinlock) {}
-        let addString;
-        if (this.props.data.stints.length > 0) {
-            addString = this.props.data.id + "," + this.props.data.stints[this.props.data.stints.length - 1].end_date;
-        } else {
-            addString = this.props.data.id + ",2016-11-03";
-        }
-        if (!(addString in this.props.updated_niceties)) {
-            this.props.updated_niceties.add(addString);
-        }
-        store.set("saved", false);
-        this.props.saveReady();
-    },
-    textareaChange: function(event) {
-        this.setState({textValue: event.target.value});
-        store.set("nicety-" + this.props.data.id, event.target.value);
-        this.updateSave();
-    },
-    anonymousChange: function(event) {
-        this.setState({anonValue: event.target.checked});
-        store.set("anonymous-" + this.props.data.id, event.target.checked);
-        this.updateSave();
-    },
-    noReadChange: function(event) {
-        this.setState({noReadValue: event.target.checked});
-        store.set("no_read-" + this.props.data.id, event.target.checked);
-        this.updateSave();
-    },
-
-    // TODO: button for each person for anonymous option
-
-    // hold a callback in the parent and pass it to the child as a prop that gets called in onChange
-    // this callback would have the parent update its own min/max rows and pass this to all children
-    // but it seems like for this to work you need child.state.height (to figureo ut the new min rows)
-
-    render: function() {
-        let anonymousRender;
-        if (this.state.anonValue === true) {
-            anonymousRender = (
-                <Checkbox checked onChange={this.anonymousChange}>
-                    Submit Anonymously
-                </Checkbox>
-            );
-        } else if (this.state.anonValue === false) {
-            anonymousRender = (
-                <Checkbox onChange={this.anonymousChange}>
-                    Submit Anonymously
-                </Checkbox>
-            );
-        }
-
-        let noReadRender;
-        if (this.state.noReadValue === true) {
-            noReadRender = (
-                <Checkbox checked onChange={this.noReadChange}>
-                    Don't Read At Ceremony
-                </Checkbox>
-            );
-        } else if (this.state.noReadValue === false) {
-            noReadRender = (
-                <Checkbox onChange={this.noReadChange}>
-                    Don't Read At Ceremony
-                </Checkbox>
-            );
-        }
-        return (
-            <div className="person">
-                <Image responsive={true} src={this.props.data.avatar_url} circle={true} />
-                <h3>{this.props.data.name}</h3>
-            <textarea
-                defaultValue={this.state.textValue}
-                onChange={this.textareaChange}
-                rows="6"
-                placeholder={this.props.data.placeholder}
-            />
-            {anonymousRender}
-            {noReadRender}
-            </div>
-        );
     }
-});
+    let dateUpdated;
+    if (foundPerson) {
+        if (dataPerson.date_updated === null) {
+            dateUpdated = '';
+        } else {
+            dateUpdated = dataPerson.date_updated;
+        }
+    }
+    if (foundPerson && store.get("date_updated-" + props.data.id) === null) {
+        if (dataPerson.text !== '' && dataPerson.text !== null) {
+            store.set("nicety-" + props.data.id, dataPerson.text);
+            textValue = dataPerson.text;
+        } else {
+            textValue = '';
+        }
+        store.set("anonymous-" + props.data.id, dataPerson.anonymous);
+        anonValue = dataPerson.anonymous;
+        store.set("no_read-" + props.data.id, dataPerson.no_read);
+        noReadValue = dataPerson.no_read;
+        store.set("date_updated-" + props.data.id, dateUpdated);
+    } else if (foundPerson && store.get("date_updated-" + props.data.id) !== dateUpdated) {
+        if (dataPerson.text !== '' && dataPerson.text !== null) {
+            store.set("nicety-" + props.data.id, dataPerson.text);
+            textValue = dataPerson.text;
+        } else {
+            textValue = '';
+        }
+        store.set("anonymous-" + props.data.id, dataPerson.anonymous);
+        anonValue = dataPerson.anonymous;
+        store.set("no_read-" + props.data.id, dataPerson.no_read);
+        noReadValue = dataPerson.no_read;
+        store.set("date_updated-" + props.data.id, dateUpdated);
+    } else {
+        if (store.get("nicety-" + props.data.id) !== null) {
+            textValue = store.get("nicety-" + props.data.id);
+        }
+        if (store.get("anonymous-" + props.data.id) !== null) {
+            anonValue = store.get("anonymous-" + props.data.id);
+        }
+        if (store.get("no_read-" + props.data.id) !== null) {
+            noReadValue = store.get("no_read-" + props.data.id);
+        }
+    }
+
+    this.state = {
+      textValue: textValue,
+      anonValue: anonValue,
+      noReadValue: noReadValue,
+    }
+  }
+
+  updateSave = () => {
+    while (updated_niceties_spinlock) {}
+    let addString;
+    if (this.props.data.stints.length > 0) {
+        addString = this.props.data.id + "," + this.props.data.stints[this.props.data.stints.length - 1].end_date;
+    } else {
+        addString = this.props.data.id + ",2016-11-03";
+    }
+    if (!(addString in this.props.updated_niceties)) {
+        this.props.updated_niceties.add(addString);
+    }
+    store.set("saved", false);
+    this.props.saveReady();
+  }
+
+  textareaChange = (event) => {
+    this.setState({textValue: event.target.value});
+    store.set("nicety-" + this.props.data.id, event.target.value);
+    this.updateSave();
+  }
+
+  anonymousChange = (event) => {
+    this.setState({anonValue: event.target.checked});
+    store.set("anonymous-" + this.props.data.id, event.target.checked);
+    this.updateSave();
+  }
+
+  noReadChange = (event) => {
+    this.setState({noReadValue: event.target.checked});
+    store.set("no_read-" + this.props.data.id, event.target.checked);
+    this.updateSave();
+  }
+
+  render() {
+    return (
+        <div className="person">
+            <Image responsive={true} src={this.props.data.avatar_url} circle={true} />
+            <h3>{this.props.data.name}</h3>
+        <textarea
+            defaultValue={this.state.textValue}
+            onChange={this.textareaChange}
+            rows="6"
+            placeholder={this.props.data.placeholder}
+        />
+        <Checkbox checked={this.state.anonValue === true}
+          onChange={this.anonymousChange}>
+            Submit Anonymously
+        </Checkbox>
+        <Checkbox checked={this.state.noReadValue === true}
+          onChange={this.noReadChange}>
+            Don't Read At Ceremony
+        </Checkbox>
+        </div>
+    );
+  }
+}
 
 export default Person;


### PR DESCRIPTION
This commit converts Person to use ES6 classes instead of React.createClass, a pre-requisite for migrating from React 15 to 16. It uses `constructor`, a JS builtin, to create the initial state - I'm not 100% sure that's the right way to go and would appreciate feedback on that. Otherwise the function body is nearly unchanged, except for a simplification of Checkbox state in `render`.