### PR TITLE
migrate App.js to class component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,59 +29,43 @@ class App extends React.Component {
   }
 
     loadPeopleFromServer = (callback) => {
-        $.ajax({
-            url: this.props.people_api,
-            dataType: 'json',
-            cache: false,
-            success: (data) => {
-                callback(data);
-            },
-            error: (xhr, status, err) => {
-                //console.error(this.props.people, status, err.toString());
-            },
-        });
+      fetch(this.props.people_api, {
+        headers: {'Content-Type': "application/json"},
+        cache: 'no-cache'
+      })
+      .then(response => response.json())
+      .then(data => callback(data))
+      .catch(err => console.log(err))
     }
 
     loadNicetiesFromMe = (callback) => {
-        $.ajax({
-            url: this.props.from_me_api,
-            dataType: 'json',
-            cache: false,
-            success: (data) => {
-                callback(data);
-            },
-            error: (xhr, status, err) => {
-                //console.error(this.props.fromMe, status, err.toString());
-            },
-        });
+      fetch(this.props.from_me_api, {
+        headers: {'Content-Type': "application/json"},
+        cache: 'no-cache'
+      })
+      .then(response => response.json())
+      .then(data => callback(data))
+      .catch(err => console.log(err))
     }
 
     loadNicetiesForMe = (callback) => {
-        $.ajax({
-            url: this.props.for_me_api,
-            dataType: 'json',
-            cache: false,
-            success: (data) => {
-                callback(data);
-            },
-            error: (xhr, status, err) => {
-                //console.error(this.props.niceties, status, err.toString());
-            },
-        });
+      fetch(this.props.for_me_api, {
+        headers: {'Content-Type': "application/json"},
+        cache: 'no-cache'
+      })
+      .then(response => response.json())
+      .then(data => callback(data))
+      .catch(err => console.log(err))
     }
 
     loadSelfInfo = (callback) => {
-        $.ajax({
-            url: this.props.self_api,
-            dataType: 'json',
-            cache: false,
-            success: (data) => {
-                callback(data);
-            },
-            error: (xhr, status, err) => {
-                //console.error(this.props.niceties, status, err.toString());
-            },
-        });
+      fetch(this.props.self_api, {
+        headers: {'Content-Type': "application/json"},
+        cache: 'no-cache'
+      })
+      .then(response => response.json())
+      .then(data => callback(data))
+      .catch(err => console.log(err))
     }
 
     componentDidMount = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -34,22 +34,14 @@ class App extends React.Component {
         cache: 'no-cache'
       })
       .then(response => response.json())
-      .then(data => {
-        let newState = {}
-        newState[dataVar] = data
-        this.setState(newState)
-      })
+      .then(data => this.setState({[dataVar]: data}))
       .catch(err => console.log(err))
     }
 
     componentDidMount = () => {
-      // loadPeopleFromServer
       this.loadData(this.props.people_api, "people")
-      // loadNicetiesFromMe
       this.loadData(this.props.from_me_api, "fromMe")
-      // loadNicetiesForMe
       this.loadData(this.props.for_me_api, "niceties")
-      // loadSelfInfo
       this.loadData(this.props.self_api, "selfInfo")
     }
 

--- a/src/App.js
+++ b/src/App.js
@@ -25,62 +25,32 @@ class App extends React.Component {
         niceties: [],
         currentview: "write-niceties",
         selfInfo: []
+      }
     }
-  }
 
-    loadPeopleFromServer = (callback) => {
-      fetch(this.props.people_api, {
+    loadData = (api, dataVar) => {
+      fetch(api, {
         headers: {'Content-Type': "application/json"},
         cache: 'no-cache'
       })
       .then(response => response.json())
-      .then(data => callback(data))
-      .catch(err => console.log(err))
-    }
-
-    loadNicetiesFromMe = (callback) => {
-      fetch(this.props.from_me_api, {
-        headers: {'Content-Type': "application/json"},
-        cache: 'no-cache'
+      .then(data => {
+        let newState = {}
+        newState[dataVar] = data
+        this.setState(newState)
       })
-      .then(response => response.json())
-      .then(data => callback(data))
-      .catch(err => console.log(err))
-    }
-
-    loadNicetiesForMe = (callback) => {
-      fetch(this.props.for_me_api, {
-        headers: {'Content-Type': "application/json"},
-        cache: 'no-cache'
-      })
-      .then(response => response.json())
-      .then(data => callback(data))
-      .catch(err => console.log(err))
-    }
-
-    loadSelfInfo = (callback) => {
-      fetch(this.props.self_api, {
-        headers: {'Content-Type': "application/json"},
-        cache: 'no-cache'
-      })
-      .then(response => response.json())
-      .then(data => callback(data))
       .catch(err => console.log(err))
     }
 
     componentDidMount = () => {
-        this.loadNicetiesFromMe((data) => {
-            this.setState({fromMe: data})
-        })
-        this.loadPeopleFromServer((data) => {
-            this.setState({people: data})
-        })
-        this.loadNicetiesForMe((data) => {
-            this.setState({niceties: data})
-        })
-        this.loadSelfInfo((data) => {
-            this.setState({selfInfo: data})
-        })
+      // loadPeopleFromServer
+      this.loadData(this.props.people_api, "people")
+      // loadNicetiesFromMe
+      this.loadData(this.props.from_me_api, "fromMe")
+      // loadNicetiesForMe
+      this.loadData(this.props.for_me_api, "niceties")
+      // loadSelfInfo
+      this.loadData(this.props.self_api, "selfInfo")
     }
 
     handleSelect = (eventKey) => {

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './App.css';
 
-import { Nav, Navbar, NavDropdown, MenuItem } from 'react-bootstrap';
+import {Nav, Navbar, NavDropdown, MenuItem,} from 'react-bootstrap';
 import React from 'react';
 import $ from 'jquery';
 import store from 'store2';
@@ -12,110 +12,119 @@ import People from './components/People';
 import NicetyDisplay from './components/NicetyDisplay';
 import Admin from './components/Admin';
 
-
 if (store.get("saved") === null) {
     store.set("saved", true);
 }
 
-const App = React.createClass({
-    loadPeopleFromServer: function(callback) {
+class App extends React.Component {
+    constructor(props) {
+      super(props)
+      this.state = {
+        fromMe: [],
+        people: [],
+        niceties: [],
+        currentview: "write-niceties",
+        selfInfo: []
+    }
+  }
+
+    loadPeopleFromServer = (callback) => {
         $.ajax({
             url: this.props.people_api,
             dataType: 'json',
             cache: false,
-            success: function(data) {
+            success: (data) => {
                 callback(data);
             },
-            error: function(xhr, status, err) {
+            error: (xhr, status, err) => {
                 //console.error(this.props.people, status, err.toString());
-            }
+            },
         });
-    },
-    loadNicetiesFromMe: function(callback) {
+    }
+
+    loadNicetiesFromMe = (callback) => {
         $.ajax({
             url: this.props.from_me_api,
             dataType: 'json',
             cache: false,
-            success: function(data) {
+            success: (data) => {
                 callback(data);
             },
-            error: function(xhr, status, err) {
+            error: (xhr, status, err) => {
                 //console.error(this.props.fromMe, status, err.toString());
-            }
+            },
         });
-    },
-    loadNicetiesForMe: function(callback) {
+    }
+
+    loadNicetiesForMe = (callback) => {
         $.ajax({
             url: this.props.for_me_api,
             dataType: 'json',
             cache: false,
-            success: function(data) {
+            success: (data) => {
                 callback(data);
             },
-            error: function(xhr, status, err) {
+            error: (xhr, status, err) => {
                 //console.error(this.props.niceties, status, err.toString());
-            }
+            },
         });
-    },
-    loadSelfInfo: function(callback) {
+    }
+
+    loadSelfInfo = (callback) => {
         $.ajax({
             url: this.props.self_api,
             dataType: 'json',
             cache: false,
-            success: function(data) {
+            success: (data) => {
                 callback(data);
             },
-            error: function(xhr, status, err) {
+            error: (xhr, status, err) => {
                 //console.error(this.props.niceties, status, err.toString());
-            }
+            },
         });
-    },
-    getInitialState: function() {
-        return {
-                fromMe: [],
-                people: [],
-                niceties: [],
-                currentview: "write-niceties",
-                selfInfo: [],
-        };
-    },
-    componentDidMount: function() {
-      this.loadNicetiesFromMe((data) => {
-        this.setState({fromMe: data})
-      })
-      this.loadPeopleFromServer((data) => {
-        this.setState({people: data})
-      })
-      this.loadNicetiesForMe((data) => {
-        this.setState({niceties: data})
-      })
-      this.loadSelfInfo((data) => {
-        this.setState({selfInfo: data})
-      })
-    },
-    handleSelect: function(eventKey) {
+    }
+
+    componentDidMount = () => {
+        this.loadNicetiesFromMe((data) => {
+            this.setState({fromMe: data})
+        })
+        this.loadPeopleFromServer((data) => {
+            this.setState({people: data})
+        })
+        this.loadNicetiesForMe((data) => {
+            this.setState({niceties: data})
+        })
+        this.loadSelfInfo((data) => {
+            this.setState({selfInfo: data})
+        })
+    }
+
+    handleSelect = (eventKey) => {
         this.setState({currentview: eventKey});
-    },
-    selectComponent: function(idx) {
-        switch(idx) {
-        case "write-niceties":
-            $('.dropdown-toggle').text('Write Niceties');
-            $('.dropdown-toggle').append('<span class="caret"></span>');
-            return <People people={this.state.people}
-                            fromMe={this.state.fromMe}
-                            save_nicety_api={this.props.save_nicety_api} />
-        case "view-niceties":
-            $('.dropdown-toggle').text('Niceties About You');
-            $('.dropdown-toggle').append('<span class="caret"></span>');
-            return <NicetyDisplay niceties={this.state.niceties} />
-        case "admin":
-            $('.dropdown-toggle').text('Admin');
-            $('.dropdown-toggle').append('<span class="caret"></span>');
-            return <Admin admin_edit_api={this.props.admin_edit_api}/>
-        default:
+    }
+
+    selectComponent = (idx) => {
+        switch (idx) {
+            case "write-niceties":
+                $('.dropdown-toggle').text('Write Niceties');
+                $('.dropdown-toggle').append('<span class="caret"></span>');
+                return <People
+                    people={this.state.people}
+                    fromMe={this.state.fromMe}
+                    save_nicety_api={this.props.save_nicety_api}/>
+            case "view-niceties":
+                $('.dropdown-toggle').text('Niceties About You');
+                $('.dropdown-toggle').append('<span class="caret"></span>');
+                return <NicetyDisplay niceties={this.state.niceties}/>
+            case "admin":
+                $('.dropdown-toggle').text('Admin');
+                $('.dropdown-toggle').append('<span class="caret"></span>');
+                return <Admin admin_edit_api={this.props.admin_edit_api}/>
+            default:
         }
-    },
-    render: function() {
+    }
+
+    render() {
         let selectedComponent = this.selectComponent(this.state.currentview);
         let adminMenu = null;
         if (this.state.selfInfo.admin === true) {
@@ -123,27 +132,27 @@ const App = React.createClass({
         }
         return (
             <div className="App">
-                <Navbar fixedTop id="main_nav">
-                <div id="title">
-                    recurse<br />
-                    nice-<br />
-                    ties
-                </div>
-                <img id="octotie" src={octotie} height="153"/>
+                <Navbar fixedTop="fixedTop" id="main_nav">
+                    <div id="title">
+                        recurse<br/>
+                        nice-<br/>
+                        ties
+                    </div>
+                    <img id="octotie" src={octotie} alt="" height="153"/>
                     <Nav activeKey={this.state.currentview} onSelect={this.handleSelect}>
                         <NavDropdown>
-                            <MenuItem eventKey="write-niceties" >Write Niceties</MenuItem>
-                            <MenuItem eventKey="view-niceties" >Niceties About You</MenuItem>
+                            <MenuItem eventKey="write-niceties">Write Niceties</MenuItem>
+                            <MenuItem eventKey="view-niceties">Niceties About You</MenuItem>
                             {adminMenu}
                         </NavDropdown>
                     </Nav>
                 </Navbar>
-              <div id="component_frame">
-                {selectedComponent}
-              </div>
+                <div id="component_frame">
+                    {selectedComponent}
+                </div>
             </div>
         );
     }
-});
+}
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -78,13 +78,13 @@ class App extends React.Component {
         }
         return (
             <div className="App">
-                <Navbar fixedTop="fixedTop" id="main_nav">
+                <Navbar fixedTop id="main_nav">
                     <div id="title">
                         recurse<br/>
                         nice-<br/>
                         ties
                     </div>
-                    <img id="octotie" src={octotie} alt="" height="153"/>
+                    <img id="octotie" src={octotie} alt="an octopus wearing a nice tie" height="153"/>
                     <Nav activeKey={this.state.currentview} onSelect={this.handleSelect}>
                         <NavDropdown>
                             <MenuItem eventKey="write-niceties">Write Niceties</MenuItem>

--- a/src/components/Admin.js
+++ b/src/components/Admin.js
@@ -3,9 +3,12 @@ import React from 'react';
 import AdminNicety from './AdminNicety';
 
 class Admin extends React.Component {
-  state = {
+  constructor(props) {
+    super(props);
+    this.state = {
     niceties: []
   }
+}
 
   loadAllNiceties = (callback) => {
     fetch(this.props.admin_edit_api, {

--- a/src/components/AdminNicety.js
+++ b/src/components/AdminNicety.js
@@ -11,6 +11,7 @@ class AdminNicety extends React.Component {
         noSave: true,
         reviewedValue: this.props.nicety.reviewed,
     }
+  }
 
     reviewedChange = (event) => {
         this.setState({reviewedValue: event.target.checked, noSave: false,});

--- a/src/components/AdminNicety.js
+++ b/src/components/AdminNicety.js
@@ -4,7 +4,9 @@ import {Checkbox} from 'react-bootstrap';
 import SaveButton from './SaveButton';
 
 class AdminNicety extends React.Component {
-    state = {
+    constructor(props) {
+      super(props)
+      this.state = {
         text: this.props.nicety.text,
         noSave: true,
         reviewedValue: this.props.nicety.reviewed,

--- a/src/components/People.js
+++ b/src/components/People.js
@@ -9,12 +9,15 @@ import SaveButton from "./SaveButton";
 export let updated_niceties_spinlock = false;
 
 class People extends React.Component {
-  state = {
+  constructor(props) {
+    super(props);
+    this.state = {
     data: [],
     noSave: store.get("saved"),
     justSaved: false,
     updated_niceties: new Set()
   }
+}
 
   saveAllComments = () => {
       updated_niceties_spinlock = true;


### PR DESCRIPTION
React.createClass is deprecated in React 15.5.0. App has state, so it isn't eligible to become a functional component. In the meantime, convert it to use regular ES6 classes. I also upgraded the data loading functions to use fetch instead of jQuery - note that jQuery is still used for menu switching so we can't get rid of it yet.

This PR also converts keyword functions to arrow functions, and adds a constructor method for several components which didn't have it. (This might be non-required in React 15 but required in 16.)

I rebuilt the front-end and checked that the app can successfully save a nicety and load Niceties for Me and Admin Niceties.