### PR TITLE
enhancements: remove edit/review functionality for admins, img title text

### DIFF
--- a/src/components/Admin.js
+++ b/src/components/Admin.js
@@ -44,10 +44,7 @@ class Admin extends React.Component {
                 <br/> {
                   person.niceties.map((nicety) => {
                     return (
-                      <AdminNicety
-                        nicety={nicety}
-                        target_id={person.to_id}
-                        admin_edit_api={this.props.admin_edit_api}/>
+                      <AdminNicety nicety={nicety}/>
                     );
                   })
                 }

--- a/src/components/AdminNicety.js
+++ b/src/components/AdminNicety.js
@@ -1,90 +1,33 @@
 import React from 'react';
-import {Checkbox} from 'react-bootstrap';
 
-import SaveButton from './SaveButton';
-
-class AdminNicety extends React.Component {
-    constructor(props) {
-      super(props)
-      this.state = {
-        text: this.props.nicety.text,
-        noSave: true,
-        reviewedValue: this.props.nicety.reviewed,
-    }
-  }
-
-    reviewedChange = (event) => {
-        this.setState({reviewedValue: event.target.checked, noSave: false,});
+const AdminNicety = (props) => {
+    let nicetyName;
+    if ('name' in props.nicety) {
+        nicetyName = props.nicety.name;
+    } else {
+        nicetyName = 'Anonymous';
     }
 
-    saveNicety = () => {
-        const data = {
-            text: this.state.text,
-            author_id: this.props.nicety.author_id,
-            end_date: this.props.nicety.end_date,
-            target_id: this.props.target_id,
-            faculty_reviewed: this.state.reviewedValue,
-        }
-        fetch(this.props.admin_edit_api, {
-          method: 'POST',
-          headers: {
-            'Content-Type': "application/json",
-          },
-          cache: 'no-cache',
-          body: JSON.stringify(data),
-        })
-        .then(() => this.setState({noSave: true}))
-        .catch((err) => console.log(err))
+    let noRead = null;
+    if (props.nicety.no_read === true) {
+        noRead = "Don't Read At Ceremony, Please";
     }
 
-    textareaChange = (event) => {
-        this.setState({text: event.target.value, noSave: false,});
+    let nicetyReturn = null;
+    if (props.nicety.text !== '' && props.nicety.text !== null) {
+        const textStyle = {
+            width: '75%',
+            whiteSpace: 'pre-wrap'
+        }
+        nicetyReturn = (
+            <div>
+                <h4>From {nicetyName}</h4>
+                <h5>{noRead}</h5>
+                <p style={textStyle}>{props.nicety.text}</p>
+            </div>
+        );
     }
-
-    render() {
-        let reviewedRender;
-        if (this.state.reviewedValue === true) {
-            reviewedRender = (
-                <Checkbox checked="checked" onChange={this.reviewedChange}>
-                    Reviewed
-                </Checkbox>
-            );
-        } else if (this.state.reviewedValue === false) {
-            reviewedRender = (
-                <Checkbox onChange={this.reviewedChange}>
-                    Reviewed
-                </Checkbox>
-            );
-        }
-
-        let nicetyName;
-        if ('name' in this.props.nicety) {
-            nicetyName = this.props.nicety.name;
-        } else {
-            nicetyName = 'Anonymous';
-        }
-
-        let noRead = null;
-        if (this.props.nicety.no_read === true) {
-            noRead = "Don't Read At Ceremony, Please";
-        }
-
-        let nicetyReturn = null;
-        if (this.props.nicety.text !== '' && this.props.nicety.text !== null) {
-            const textStyle = {
-                width: '75%',
-                whiteSpace: 'pre-wrap'
-            }
-            nicetyReturn = (
-                <div>
-                    <h4>From {nicetyName}</h4>
-                    <h5>{noRead}</h5>
-                    <p style={textStyle}>{this.props.nicety.text}</p>
-                </div>
-            );
-        }
-        return nicetyReturn;
-    }
+    return nicetyReturn;
 }
 
 export default AdminNicety;

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -106,7 +106,7 @@ class Person extends React.Component {
     render() {
         return (
             <div className="person">
-                <Image responsive={true} src={this.props.data.avatar_url} circle={true}/>
+                <Image responsive={true} src={this.props.data.avatar_url} title={this.props.data.full_name} circle={true}/>
                 <h3>{this.props.data.name}</h3>
                 <textarea
                     defaultValue={this.state.textValue}


### PR DESCRIPTION
This PR includes a migration of AdminNicety from a class to a functional component, and a simplification of the props passed into it in Admin. I realized this was possible once I removed code related to editing and reviewing niceties, since we've been informed that's not really a use-case for admins.

I also added the user's full name as a title (hover-text) for each photo, in case there are two Sams in your batch and you can't quite recall which is which.