### PR TITLE
convert Admin to use hooks

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -158,11 +158,17 @@ def get_admin_niceties():
     three_weeks_ago = datetime.now() - timedelta(days=21)
     three_weeks_from_now = datetime.now() + timedelta(days=21)
     if is_admin is True:
-        valid_niceties = (Nicety.query
-                          .filter(Nicety.end_date > three_weeks_ago)
-                          .filter(Nicety.end_date < three_weeks_from_now)
-                          .order_by(Nicety.target_id)
-                          .all())
+        if app.config.get("DEBUG_SHOW_ALL") == "TRUE":
+            valid_niceties = (Nicety.query
+                              .filter(Nicety.end_date > three_weeks_ago)
+                              .order_by(Nicety.target_id)
+                              .all())
+        else:
+            valid_niceties = (Nicety.query
+                              .filter(Nicety.end_date > three_weeks_ago)
+                              .filter(Nicety.end_date < three_weeks_from_now)
+                              .order_by(Nicety.target_id)
+                              .all())
         for n in valid_niceties:
             if n.target_id != last_target:
                 # ... set up the test for the next one

--- a/src/components/Admin.js
+++ b/src/components/Admin.js
@@ -1,17 +1,10 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 import AdminNicety from './AdminNicety';
 
-class Admin extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-    niceties: []
-  }
-}
-
-  loadAllNiceties = (callback) => {
-    fetch(this.props.admin_edit_api, {
+function Admin(props) {
+  const loadAllNiceties = (callback) => {
+    fetch(props.admin_edit_api, {
       headers: {
         'Content-Type': "application/json"
       },
@@ -22,22 +15,21 @@ class Admin extends React.Component {
     .catch((err) => console.log(err))
   }
 
-  componentDidMount = () => {
-    this.loadAllNiceties((data) => this.setState({niceties: data})
-    );
-  }
+  const [adminNiceties, setAdminNiceties] = useState([]);
+  useEffect(() => {
+    loadAllNiceties((data) => setAdminNiceties(data));
+  }, [])
 
-  render() {
-    return (
+  return (
       <div>
-        {this.state.niceties.map((person) => {
-          let noTextCheck = false;
+        {adminNiceties.map((person) => {
+          let textCheck = false;
           person.niceties.forEach((nicety) => {
             if (nicety.text !== '' && nicety.text !== null) {
-              noTextCheck = true;
+              textCheck = true;
             }
           });
-          if (noTextCheck) {
+          if (textCheck) {
             return (
               <div>
                 <h2>To {person.to_name}</h2>
@@ -58,6 +50,5 @@ class Admin extends React.Component {
       </div>
     );
   }
-}
 
 export default Admin;

--- a/src/components/Admin.js
+++ b/src/components/Admin.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 import AdminNicety from './AdminNicety';
 
-function Admin(props) {
+const Admin = (props) => {
   const loadAllNiceties = (callback) => {
     fetch(props.admin_edit_api, {
       headers: {

--- a/src/components/PeopleRow.js
+++ b/src/components/PeopleRow.js
@@ -11,7 +11,6 @@ const PeopleRow = (props) => (
                     fromMe={props.fromMe}
                     data={result}
                     saveReady={props.saveReady}
-                    saveButton={props.saveButton}
                     updated_niceties={props.updated_niceties}
                 />
             </Col>


### PR DESCRIPTION
This PR actually incorporates 4 changes:
- converts Admin to be a function component using useState and useEffect hooks
- when DEBUG_SHOW_ALL is TRUE, make it easier to debug the Admin page by showing all niceties from the previous **and** current batches, allowing you to write some niceties and have them immediately show up even when it's not the last 3 weeks of a batch
- change the name of `noTextCheck` to `textCheck` to be less confusing
- remove an unused prop from PeopleRow

I confirmed that the niceties I expected to see, show up on the Admin page without an infinite rendering loop.