### PR TITLE
Remove unused columns

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -322,7 +322,7 @@ def save_niceties():
             # So then db.session.commit() sends the update (or insert) for every object
             # in the session. This includes every object created by a [model].query and
             # everything added to the session with db.session.add().
-        nicety.anonymous = n.get("anonymous", current_user().anonymous_by_default)
+        nicety.anonymous = n.get("anonymous", False)
         text = util.encode_str(n.get("text").strip())
         if '' == text:
             text = None

--- a/backend/models.py
+++ b/backend/models.py
@@ -12,7 +12,6 @@ class User(db.Model):
     name = db.Column(db.String(500))
     avatar_url = db.Column(db.String(500), nullable=True)
     faculty = db.Column(db.Boolean)
-    anonymous_by_default = db.Column(db.Boolean)
     random_seed = db.Column(db.LargeBinary(32))
 
     def __init__(self, id, name, **kwargs):
@@ -20,7 +19,6 @@ class User(db.Model):
         self.name = name
         self.avatar_url = kwargs.get("avatar_url", None)
         self.faculty = kwargs.get("faculty", None)
-        self.anonymous_by_default = kwargs.get("anonymous_by_default", False)
         self.random_seed = urandom(32)
 
     def __repr__(self):

--- a/backend/models.py
+++ b/backend/models.py
@@ -13,8 +13,6 @@ class User(db.Model):
     avatar_url = db.Column(db.String(500), nullable=True)
     faculty = db.Column(db.Boolean)
     anonymous_by_default = db.Column(db.Boolean)
-    autosave_timeout = db.Column(db.Integer)
-    autosave_enabled = db.Column(db.Boolean)
     random_seed = db.Column(db.LargeBinary(32))
 
     def __init__(self, id, name, **kwargs):
@@ -23,8 +21,6 @@ class User(db.Model):
         self.avatar_url = kwargs.get("avatar_url", None)
         self.faculty = kwargs.get("faculty", None)
         self.anonymous_by_default = kwargs.get("anonymous_by_default", False)
-        self.autosave_timeout = kwargs.get("autosave_timeout", 10)
-        self.autosave_enabled = kwargs.get("autosave_enabled", True)
         self.random_seed = urandom(32)
 
     def __repr__(self):
@@ -39,7 +35,6 @@ class Nicety(db.Model):
     author_id = db.Column(db.ForeignKey('user.id'))  # RC user ID
     target_id = db.Column(db.Integer)  # RC user ID
     anonymous = db.Column(db.Boolean)
-    starred = db.Column(db.Boolean)
     text = db.Column(db.Text, nullable=True)
     no_read = db.Column(db.Boolean)
     date_updated = db.Column(db.Text)
@@ -51,7 +46,6 @@ class Nicety(db.Model):
         self.author_id = author_id
         self.target_id = target_id
         self.anonymous = kwargs.get("anonymous", False)
-        self.starred = kwargs.get("starred", False)
         self.text = kwargs.get("text", None)
         self.no_read = kwargs.get("no_read", False)
         self.date_updated = kwargs.get("date_updated", "")

--- a/migrations/versions/689a6ce963c3_remove_anonymous_columns.py
+++ b/migrations/versions/689a6ce963c3_remove_anonymous_columns.py
@@ -1,0 +1,30 @@
+"""remove anonymous columns
+
+Revision ID: 689a6ce963c3
+Revises: c79589787f2f
+Create Date: 2022-03-08 21:27:44.689439
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '689a6ce963c3'
+down_revision = 'c79589787f2f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Giving niceties anonymously in bulk is a partially implemented
+    feature for the user.
+
+    Ultimately want to discourage this feature as well as make it easier for
+    code maintenance.
+    """
+    op.drop_column("user", "anonymous_by_default")
+
+def downgrade():
+    op.add_column("user", sa.Column("anonymous_by_default", sa.Boolean(),))

--- a/migrations/versions/c79589787f2f_remove_unused_columns.py
+++ b/migrations/versions/c79589787f2f_remove_unused_columns.py
@@ -1,0 +1,37 @@
+"""remove unused columns from nicety and user tables
+
+Revision ID: c79589787f2f
+Revises: 67ac3b7d5c2f
+Create Date: 2022-01-20 18:36:18.328917
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c79589787f2f"
+down_revision = "67ac3b7d5c2f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("nicety", "starred")
+    op.drop_column("user", "autosave_enabled")
+    op.drop_column("user", "autosave_timeout")
+
+
+def downgrade():
+    op.add_column(
+        "nicety",
+        sa.Column("starred", sa.BOOLEAN(), nullable=True),
+    )
+    op.add_column(
+        "user",
+        sa.Column("autosave_enabled", sa.BOOLEAN(), nullable=True),
+    )
+    op.add_column(
+        "user",
+        sa.Column("autosave_timeout", sa.INTEGER(), nullable=True),
+    )


### PR DESCRIPTION
Clean up the model by removing the following unused columns:


Issue #34: Remove starred column
Issue #80: Remove unused autosaved columns
```
nicety.starred
user.autosave_enabled
user.autosave_timeout
```

Issue #79: Remove unused anonymous_by_default column
```
user.anonymous_by_default
```

**Note:** This should be merged _before_ PR #95 Delete two duplicate niceties