### PR TITLE
Delete two duplicate niceties

### DIFF
--- a/migrations/versions/8d1680ddfc14_remove_duplicate_niceties.py
+++ b/migrations/versions/8d1680ddfc14_remove_duplicate_niceties.py
@@ -1,0 +1,34 @@
+"""remove two duplicate niceties
+
+Revision ID: 8d1680ddfc14
+Revises: 689a6ce963c3
+Create Date: 2022-01-20 19:11:18.433206
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "8d1680ddfc14"
+down_revision = "689a6ce963c3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Delete 2 niceties that break the unique constraint
+    "nicety_author_id_target_id_stint_id_key"
+    """
+
+    op.execute(
+        """
+        DELETE
+        FROM nicety
+        WHERE id IN (221, 3634);
+        """
+    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
These two niceties were manually reviewed and had substantially similar but not identical content to two other niceties that are from the same author_id to the same target_id. These niceties were "lost" because the target user extended their batch and had a different end_date.

In our process to normalize the Database, we create a unique constraint between author_id, target_id, and stint. These two niceties break that constraint.

Issue #82: Normalize Recurser Profiles
Issue #10: Niceties lost when Recursers extend their batch

**Note:** This should be merged _after_ PR #93 Remove Unused Columns